### PR TITLE
NPM3 compatibility and NPM script aliases for Gulp tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,11 +23,10 @@ git clone https://github.com/vega/voyager
 
 Make sure you have node.js. (We recommend using [homebrew](http://brew.sh) and simply run `brew install node`.)
 
-First, install gulp + bower globally by running
+First, install bower globally by running
 
 ```sh
 npm install -g bower
-npm install -g gulp
 ```
 
 Then, `cd` into your local clone of the repository, and install all the npm, bower dependencies:
@@ -42,7 +41,7 @@ Now you should have all dependencies and should be ready to work.
 
 ### Running
 
-You can run `gulp serve`, which serves the site as well as running tests in the background.
+You can run `npm start`, which serves the site as well as running tests in the background.
 If you edit any file, our gulp task runner should automatically refresh the browser and re-run tests.
 
 ## Development Guide
@@ -60,7 +59,7 @@ All source code are under `src/`
 - `src/vendor` contains
 
 @kanitw have create [`gulp/gen.js`](https://github.com/vega/polestar/blob/master/gulp/gen.js) for help generating angular components.
-For example, you can run `gulp gen -d directiveName` and this would create all relevant files including the javascript file, the template file, the stylesheet file and the test spec.
+For example, you can run `gulp gen -d directiveName` (requires gulp to be installed globally) and this would create all relevant files including the javascript file, the template file, the stylesheet file and the test spec.
 
 #### Coding Style
 
@@ -93,8 +92,8 @@ bower link vega-lite-ui
 
 Now all the changes you make in each repo will be reflected in your Vega-lite automatically.
 
-Since bower uses the compiled main file, make sure that each repos is compiled everytime you run `gulp serve`.
-Otherwise, you will get errors for missing libraries.
+Since bower uses the compiled main file, make sure that each repo is compiled everytime you run `npm start`.
+Otherwise, you will get errors for missing libraries or undefined globals.
 
 ### Releasing / Github Pages
 
@@ -111,5 +110,5 @@ Use `publish.sh` to:
 
 Voyager's development is led by Kanit Wongsuphasawat, Dominik Moritz, and Jeffrey Heer at the University of Washington [Interactive Data Lab](http://idl.cs.washington.edu), in collaboration with [UW eScience Institute](http://escience.washington.edu/) and [Tableau Research](http://research.tableau.com)
 
-We used [generator-gulp-angular](https://github.com/Swiip/generator-gulp-angular) for bootstraping our project.
+We used [generator-gulp-angular](https://github.com/Swiip/generator-gulp-angular) for bootstrapping our project.
 

--- a/README.md
+++ b/README.md
@@ -23,21 +23,16 @@ git clone https://github.com/vega/voyager
 
 Make sure you have node.js. (We recommend using [homebrew](http://brew.sh) and simply run `brew install node`.)
 
-First, install bower globally by running
-
-```sh
-npm install -g bower
-```
-
-Then, `cd` into your local clone of the repository, and install all the npm, bower dependencies:
+Then, `cd` into your local clone of this repository, and install all the dependencies (bower dependencies will auto-install once the npm install completes):
 
 ```sh
 cd voyager
 npm install
-bower install
 ```
 
 Now you should have all dependencies and should be ready to work.
+
+Note: Bower is used in this project to manage client-side dependencies. The necessary bower packages will auto-install when `npm install` completes. To manage bower dependencies, install bower globally as detailed in the [Dependencies development guide](#dependencies) below.
 
 ### Running
 
@@ -58,7 +53,7 @@ All source code are under `src/`
 - `src/data/` contains all data that we use in the application
 - `src/vendor` contains
 
-@kanitw have create [`gulp/gen.js`](https://github.com/vega/polestar/blob/master/gulp/gen.js) for help generating angular components.
+@kanitw has created [`gulp/gen.js`](gulp/gen.js) for help generating angular components.
 For example, you can run `gulp gen -d directiveName` (requires gulp to be installed globally) and this would create all relevant files including the javascript file, the template file, the stylesheet file and the test spec.
 
 #### Coding Style
@@ -71,11 +66,16 @@ We use [sass](http://sass-lang.com) as it is a better syntax for css.
 
 #### Dependencies
 
+Managing front-end dependencies with [Bower](http://bower.io) requires the `bower` package to be globally installed:
+```sh
+npm install -g bower
+```
+
 This project depends on [Datalib](https://github.com/vega/datalib) for data processing, [Vega-lite](https://github.com/vega/vega-lite) as a formal model for visualization, and [Vega-lite-ui](https://github.com/vega/vega-lite-ui), which contains shared components between Polestar and Voyager.
 
 If you plan to make changes to these dependencies and observe the changes without publishing / copying compiled libraries all the time, use [`bower link`](https://oncletom.io/2013/live-development-bower-component/).
 
-In each of your dependency repository, run
+In each of your dependency repositories, run
 
 ```
 cd path/to/dependency-repo
@@ -90,9 +90,9 @@ bower link vega-lite
 bower link vega-lite-ui
 ```
 
-Now all the changes you make in each repo will be reflected in your Vega-lite automatically.
+Now all the local changes you make in each repo will be reflected in Voyager automatically.
 
-Since bower uses the compiled main file, make sure that each repo is compiled everytime you run `npm start`.
+Since bower uses the compiled main file, make sure that each linked repo is compiled everytime you run `npm start`.
 Otherwise, you will get errors for missing libraries or undefined globals.
 
 ### Releasing / Github Pages

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "karma-sinon-chai": "^1.0.0",
     "main-bower-files": "~2.8.2",
     "mocha": "^2.2.5",
+    "phantomjs": "^1.9.18",
     "phantomjs-polyfill": "0.0.1",
     "protractor": "~2.1.0",
     "request": "^2.58.0",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
   "license": "BSD-3-Clause",
   "scripts": {
     "deploy": "npm run lint && npm run test && scripts/deploy.sh",
+    "build": "gulp",
+    "start": "gulp serve",
     "lint": "gulp jshint",
     "test": "gulp test"
   },

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "license": "BSD-3-Clause",
   "scripts": {
+    "postinstall": "bower install",
     "deploy": "npm run lint && npm run test && scripts/deploy.sh",
     "build": "gulp",
     "start": "gulp serve",
@@ -27,6 +28,7 @@
     "stream-series": "^0.1.1"
   },
   "devDependencies": {
+    "bower": "^1.5.2",
     "browser-sync": "~2.7.13",
     "chai": "^3.0.0",
     "chai-jquery": "^2.0.0",


### PR DESCRIPTION
- Resolve missing peer dependencies that cause errors with NPM3
- Add npm script aliases for gulp commands
- Auto-install bower packages on `npm install` using a postinstall script