### PR TITLE
Remove unnecessary steps from travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,4 @@ language: node_js
 node_js:
   - "0.12"
 before_install:
-  - npm install -g bower
   - npm install
-  - bower install


### PR DESCRIPTION
Global bower installation and explicit `bower install` should no longer be necessary for the Travis CI process to execute successfully, following #184 