### PR TITLE
Fix issue where display area does not take up full height

### DIFF
--- a/src/app/main/main.html
+++ b/src/app/main/main.html
@@ -1,5 +1,4 @@
-<div ng-controller="MainCtrl">
-  <div class="flex-root vflex full-width full-height">
+<div ng-controller="MainCtrl" class="flex-root vflex full-width full-height">
     <div class="full-width no-shrink">
       <div class="card no-right-margin no-top-margin margin-bottom">
         <div class="right flex-root hflex">
@@ -55,7 +54,7 @@
         <label><input type="checkbox" ng-model="consts.debugInList"/> Show Debug In List</label>
       </div>
     </div>
-  </div>
+
   <bookmark-list
     ng-if="Bookmarks.isSupported"
     active="bookmarksShown"

--- a/src/index.html
+++ b/src/index.html
@@ -19,9 +19,7 @@
       <p class="browsehappy">You are using an <strong>outdated</strong> browser. Please <a href="http://browsehappy.com/">upgrade your browser</a> to improve your experience.</p>
     <![endif]-->
 
-    <div class="abs-100">
-      <ng-include src="'app/main/main.html'"></ng-include>
-    </div>
+    <div class="abs-100" ng-include="'app/main/main.html'"></div>
 
     <!-- build:js(src) scripts/vendor.js -->
     <!-- bower:js -->


### PR DESCRIPTION
See vega/vega-lite-ui#73 and vega/polestar#322

This was introduced in dea6557d32c7733d220bd5dfca7bcc62f22b4dc8 while addressing an issue that prevented the bookmarks from closing: the display height issue arose due to the introduction of another layer of nesting that the CSS did not account for.

The same angular hierarchy can be achieved with less DOM nesting, so this commit addresses the overflow by removing unneeded intermediate div nodes.

Note that this did not end up being an issue with vega-lite-ui, so this closes vega/vega-lite-ui#73 as a dupe of an issue that exists separately within polestar and voyager.

Polestar commit to follow.