### PR TITLE
Re-render the visualization list when dataset changes

### DIFF
--- a/src/components/vislist/vislist.js
+++ b/src/components/vislist/vislist.js
@@ -54,7 +54,11 @@ angular.module('voyager')
           Visrec.update.projections(fieldList);
         }
 
-        var dUpdateFields = _.debounce(updateFields, 200, {maxWait: 1500});
+        var dUpdateFields = _.debounce(function() {
+          // The debounced function executes outside Angular's purview: manually
+          // restore angular context by wrapping updateFields in $apply
+          scope.$apply(updateFields);
+        }, 200, {maxWait: 1500});
 
         scope.$watch('Fields.fields', function(fields, oldFields) {
           if (!oldFields || _.keys(oldFields).length === 0 ) { // first time!


### PR DESCRIPTION
This closes #176, where the visualization list would not automatically re-render until you mouseover a pill. The reason this was happening was that the update method is debounced, and debounced methods execute outside of Angular's regular digest cycle. As such, while the Visrec object was updated, the change would not take effect until a mouseover or some other angular event handler fires, triggering a new $digest.

We could solve this problem by manually `scope.$digest`ing, but this is the use-case `$apply` was intended for: wrapping the update method in `$apply` is the most concise solution to the problem.

![toggle](https://cloud.githubusercontent.com/assets/442115/10500061/42b770de-72a3-11e5-8bd2-58e60f04f228.gif)