### PR TITLE
Try Implementing inline-block footer links as described in #205

### DIFF
--- a/src/app/index.scss
+++ b/src/app/index.scss
@@ -135,10 +135,10 @@ h2 {
       padding: 0;
       display: inline-block;
 
-      // items Separate with a white bullet
+      // Separate items with a dot
       &:after {
         color: #eee;
-        content: '\2022';
+        content: '\000b7';
         padding: 0 3px;
       }
       &:last-of-type {

--- a/src/app/index.scss
+++ b/src/app/index.scss
@@ -132,6 +132,21 @@ h2 {
     padding:0;
     li {
       margin-bottom: 4px;
+      padding: 0;
+      display: inline-block;
+
+      // items Separate with a white bullet
+      &:after {
+        color: #eee;
+        content: '\2022';
+        padding: 0 3px;
+      }
+      &:last-of-type {
+        &:after {
+          content: none;
+          padding-right: 0;
+        }
+      }
     }
   }
 }

--- a/src/app/main/main.controller.js
+++ b/src/app/main/main.controller.js
@@ -20,6 +20,10 @@ angular.module('voyager')
       Modals.open(modalId);
     };
 
+    $scope.toggleDevPanel = function() {
+      $scope.showDevPanel = ! $scope.showDevPanel;
+    };
+
     if (Bookmarks.isSupported) {
       // load bookmarks from local storage
       Bookmarks.load();

--- a/src/app/main/main.html
+++ b/src/app/main/main.html
@@ -38,14 +38,12 @@
             <li>
               <a ng-click="showDevPanel" >About</a>
             </li>
-            <span ng-show="consts.debug">
-              <li>
-                <a class="debug" ng-click="showDevPanel = !showDevPanel">Debug</a>
-              </li>
-              <li>
-                <a ng-href="{{ {fields: Fields.fields} | reportUrl }}" target="_blank" class="debug">Report an issue</a>
-              </li>
-            </span>
+            <li ng-if="consts.debug">
+              <a class="debug" ng-click="showDevPanel = !showDevPanel">Debug</a>
+            </li>
+            <li ng-if="consts.debug">
+              <a ng-href="{{ {fields: Fields.fields} | reportUrl }}" target="_blank" class="debug">Report an issue</a>
+            </li>
           </ul>
         </div>
       </div>

--- a/src/app/main/main.html
+++ b/src/app/main/main.html
@@ -36,10 +36,10 @@
         <div id="footer">
           <ul class="menu">
             <li>
-              <a ng-click="showDevPanel" >About</a>
+              <a ng-click="">About</a>
             </li>
             <li ng-if="consts.debug">
-              <a class="debug" ng-click="showDevPanel = !showDevPanel">Debug</a>
+              <a class="debug" ng-click="toggleDevPanel();">Debug</a>
             </li>
             <li ng-if="consts.debug">
               <a ng-href="{{ {fields: Fields.fields} | reportUrl }}" target="_blank" class="debug">Report an issue</a>


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/442115/10532035/7a190954-7387-11e5-86c9-60541542160b.png)

Note that this does work better for many links when there is sufficient room: if we add in the tour link, and debug mode is enabled (otherwise those other two don't display), I don't know any way to avoid that hanging bullet on the first line:

![image](https://cloud.githubusercontent.com/assets/442115/10532046/927bf77c-7387-11e5-8539-a698990f8b0a.png)

Facebook's solution (from #205) has the same problem, and it wouldn't happen in debug mode, so this may not be an issue at all.

Alternate option for the separator would be the smaller dot `\000b7` instead of the bullet &bull;, which might actually be what FB uses:

![image](https://cloud.githubusercontent.com/assets/442115/10532121/4709ace8-7388-11e5-8af9-674c594973be.png)