### PR TITLE
Workaround for tooltip opacity issue (fixes #200)

### DIFF
--- a/src/app/index.scss
+++ b/src/app/index.scss
@@ -150,3 +150,8 @@ h2 {
     }
   }
 }
+
+// Workaround for https://github.com/720kb/angular-tooltips/issues/95
+._720kb-tooltip:not(._720kb-tooltip-open) {
+  visibility: hidden !important;
+}


### PR DESCRIPTION
The CSS intended to hide a tooltip when it is not open does not work due to a CSS selector precedence issue in the angular-tooltip code. Using `!important` is generally not best-practice, but it does let us temporarily work around the problem described in issue #200 and 720kb/angular-tooltips#95

Once this issue is resolved in the angular-tooltips library this code can be deprecated and removed.