### PR TITLE
Make visual hierarchy clearer with background for section header in the `.vis-list`

### DIFF
--- a/src/components/vislist/vislist.html
+++ b/src/components/vislist/vislist.html
@@ -3,7 +3,7 @@
   <div class="exact-match-list"
     ng-if="Fields.selected.length > 0 && Visrec.aggregates[Fields.selectedPKey].length > 0">
 
-    <div class="card no-top-margin vis-list-header">
+    <div class="card vis-list-header">
       <div><span class="description">Explore visualizations of </span>
       <field-info ng-repeat="(name, field) in Fields.selected"
         field='field'
@@ -46,7 +46,7 @@
     </div>
   </div>
   <div ng-if="Fields.selected.length === 0"
-    class="card vis-list-header no-top-margin">
+    class="card vis-list-header">
     <span class="description">Explore univariate summaries of each field</span>
     <div class="explanation">
       Start exploring data by examining each field and continue by selecting interesting data fields in data selector panel.

--- a/src/components/vislist/vislist.scss
+++ b/src/components/vislist/vislist.scss
@@ -1,12 +1,14 @@
+$vis-list-margin: 5px;
+
 .vis-list-header {
-  background-color: #ECF1F7;
+  margin: $vis-list-margin $vis-list-margin 0;
+  background-color: #D7E0EA;
   .description {
     font-size: 16px;
-    margin-top:8px;
+    font-weight: bold;
   }
   .explanation {
-    font-size: 14px;
-    color: #777;
+    color: #333;
   }
   .field-info {
     margin-top: -6px;
@@ -14,9 +16,10 @@
 }
 
 .vis-list {
-  margin-left: 5px;
+  margin-left: $vis-list-margin;
+  margin-right: $vis-list-margin - 3px; // each item in .vis-list already have margin-right: 3px
+  margin-bottom: 20px;
   align-content: flex-start;
-  margin-bottom: 10px;
   background-color: #ECF1F7;
 }
 


### PR DESCRIPTION
Make visual hierarchy clearer with background for section header in the `.vis-list`

Fixes #206

The following screenshots also show darker header background color from https://github.com/vega/vega-lite-ui/pull/123. 


![data_voyager](https://cloud.githubusercontent.com/assets/111269/10555227/aa5a5b1a-7420-11e5-9ff9-aab86deafbb5.png)

Scrolling down we can see that the header is slightly different from the chart's white background.
Not sure if I should make it darker to make the distinction clearer, but we should make it too dark as the logos are designed for white or almost white background.  Otherwise, we have to switch to solid color logo, at least for the IDL logo.  

![data_voyager](https://cloud.githubusercontent.com/assets/111269/10555235/c74b0ac6-7420-11e5-8c84-0840e1406659.png)

@vlandham @domoritz  -- ready for review


