### PR TITLE
Get style source maps working (fixes #281)

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
   "license": "BSD-3-Clause",
   "scripts": {
     "start": "webpack-dev-server --open",
-    "build": "webpack -d",
-    "watch": "webpack -d --watch",
+    "build": "webpack --debug",
+    "watch": "webpack --debug --watch",
     "clean": "find -E dist  -regex '.*\\.(js|js.map|d.ts)' -delete",
     "lint": "tslint -c tslint.json 'src/**/*.ts' 'src/**/*.tsx'",
     "lint-fix": "npm run lint -- --fix",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -35,8 +35,9 @@ module.exports = {
   },
 
   // Enable sourcemaps for debugging webpack's output.
-  devtool: 'cheap-eval-source-map',
-  // devtool: "source-map", // this is better for production
+  // If it is inline, it will break CSS sourcemaps because of
+  // `extract-text-webpack-plugin`
+  devtool: 'source-map',
 
   devServer: {
     contentBase: __dirname,
@@ -82,6 +83,7 @@ module.exports = {
           }, {
             loader: "sass-loader",
              options: {
+               sourceMap: true,
                includePaths: [
                  path.resolve(__dirname, "node_modules/normalize-scss/sass")
                ]


### PR DESCRIPTION
In order to get source maps working for SASS, had to switch to the `source-map` devtool, which is [recommended by `extract-text`](https://github.com/webpack-contrib/extract-text-webpack-plugin/tree/58dd5d31735dd801cba43c87700f4d6144203c75#usage).

I also had to stop using the `-d` CLI flag for `webpack`, because it overrides `devtool` and replaced it with `--debug`, which it includes.