### PR TITLE
fixes a regression introduced in #340. show dataset selector in app

### DIFF
--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -65,7 +65,9 @@ class AppBase extends React.PureComponent<Props, {}> {
       }
     }
 
-    this.setConfig(config);
+    if (config) {
+      this.setConfig(config);
+    }
   }
 
   private loadData(data: InlineData) {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -6,10 +6,13 @@ import 'font-awesome-sass-loader';
 
 import { Data } from 'vega-lite/build/src/data';
 import { App } from './components/app';
+import { VoyagerConfig } from './models/config';
 import { configureStore } from './store';
 
 const store = configureStore();
-const config = {};
+const config: VoyagerConfig = {
+  showDataSourceSelector: true
+};
 const data: Data = undefined;
 
 ReactDOM.render(


### PR DESCRIPTION
This is a fix to a regression i am seeing where the dataset selector isn't being shown when no config is passed. I thought this was addressed in #340 but must have missed something. This sets it explicitly in the app. 

I'll try to track down whats happening with the default but this should be good to keep anyway.