### PR TITLE
export types used in api

### DIFF
--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -7,6 +7,8 @@ import {build as buildSchema, Schema} from 'compassql/build/src/schema';
 import {Data} from 'vega-lite/build/src/data';
 import {convertToPlotObjectsGroup, PlotObject} from '../models/plot';
 
+export {Query, Schema, Data};
+
 export function fetchCompassQLRecommend(query: Query, schema: Schema, data: Data, config?: any):
   Promise<SpecQueryGroup<PlotObject>> {
 


### PR DESCRIPTION
For voyager-server, we need to call voyager code to generate recommend output. One way to do that is just to call the `api` function - as we would on the client. 

A problem with every scenario i've found so far is when trying to use class declarations directly from compassql, typescript cannot tell that the class declarations from compassql and the class declarations from compassql -> voyager are the same class.

For example, `fetchCompassQLRecommend` takes a `Schema` instance. This `Schema` comes from compassql, but typescript gives an error as it cannot discover that. 

The option to get around this is presented in this PR. We basically export compassql types somewhere in voyager (here they are in the api - but it could be a separate file). and then we can use these types instead of types directly from compassql. 

Thoughts?