### PR TITLE
Group actions so that they can be undone/redone in a single step. Rem…

### DIFF
--- a/src/actions/dataset.ts
+++ b/src/actions/dataset.ts
@@ -16,13 +16,13 @@ import {getConfig} from '../selectors';
 export type DatasetAction = DatasetUrlReceive | DatasetUrlRequest | DatasetReceive;
 export type DatasetAsyncAction = DatasetLoad;
 
-export const DATASET_URL_REQUEST = 'DATA_URL_REQUEST';
+export const DATASET_URL_REQUEST = 'DATASET_URL_REQUEST';
 export type DatasetUrlRequest = ReduxAction<typeof DATASET_URL_REQUEST, {
   name: string,
   url: string
 }>;
 
-export const DATASET_URL_RECEIVE = 'DATA_URL_RECEIVE';
+export const DATASET_URL_RECEIVE = 'DATASET_URL_RECEIVE';
 export type DatasetUrlReceive = ReduxAction<typeof DATASET_URL_RECEIVE, {
   name: string,
   url: string,

--- a/src/actions/index.ts
+++ b/src/actions/index.ts
@@ -16,3 +16,34 @@ export * from './undo-redo';
  * Union type of all actions in our application.
  */
 export type Action = DatasetAction | ShelfAction | UndoableAction | ResultAction | ConfigAction;
+
+export type ActionType = Action['type'];
+
+// Use type to enforce that ACTION_TYPE_INDEX contains all action types.
+const ACTION_TYPE_INDEX: {[k in ActionType]: 1} = {
+  DATASET_URL_REQUEST: 1,
+  DATASET_URL_RECEIVE: 1,
+  DATASET_INLINE_RECEIVE: 1,
+
+  RESULT_RECEIVE: 1,
+  RESULT_REQUEST: 1,
+
+  SET_CONFIG: 1,
+
+  SHELF_CLEAR: 1,
+  SHELF_MARK_CHANGE_TYPE: 1,
+  SHELF_FIELD_ADD: 1,
+  SHELF_FIELD_AUTO_ADD: 1,
+  SHELF_FIELD_MOVE: 1,
+  SHELF_FIELD_REMOVE: 1,
+  SHELF_FUNCTION_CHANGE: 1,
+  SHELF_SPEC_LOAD: 1,
+  SHELF_SPEC_PREVIEW: 1,
+  SHELF_SPEC_PREVIEW_DISABLE: 1,
+
+  UNDO: 1,
+  REDO: 1,
+};
+
+/** An array of all possible action types. */
+export const ACTION_TYPES = Object.keys(ACTION_TYPE_INDEX) as ActionType[];

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -6,7 +6,7 @@ import HTML5Backend from 'react-dnd-html5-backend';
 import * as SplitPane from 'react-split-pane';
 
 import {Dispatch} from 'redux';
-import {StateWithHistory} from 'redux-undo';
+import {ActionCreators, StateWithHistory} from 'redux-undo';
 import {Data} from 'vega-lite/build/src/data';
 import {datasetLoad, SET_CONFIG} from '../actions';
 import {StateBase} from '../models/index';
@@ -37,6 +37,7 @@ class AppBase extends React.PureComponent<Props, {}> {
   }
 
   public componentWillMount() {
+    this.props.dispatch(ActionCreators.clearHistory());
     this.update(this.props);
   }
 

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -37,6 +37,9 @@ class AppBase extends React.PureComponent<Props, {}> {
   }
 
   public componentWillMount() {
+    // Clear history as redux-undo seems to always put the first action after
+    // an init into the history. This ensures we start with a fresh history once
+    // the app is about to start.
     this.props.dispatch(ActionCreators.clearHistory());
     this.update(this.props);
   }

--- a/src/reducers/index.test.ts
+++ b/src/reducers/index.test.ts
@@ -4,15 +4,15 @@ import {ACTIONS_EXCLUDED_FROM_HISTORY, GROUPED_ACTIONS, USER_ACTIONS} from './in
 describe('reducers/index', () => {
   describe("Action Groups", () => {
     it('All actions should be in a group', () => {
-      const actionsInIndex = ACTIONS_EXCLUDED_FROM_HISTORY.concat(
+      const actionsInIndex = [].concat(
+        ACTIONS_EXCLUDED_FROM_HISTORY,
         GROUPED_ACTIONS,
-        Object.keys(USER_ACTIONS),
+        USER_ACTIONS
       );
 
       for (const action of ACTION_TYPES) {
         expect(actionsInIndex).toContain(action);
       }
-
     });
   });
 });

--- a/src/reducers/index.test.ts
+++ b/src/reducers/index.test.ts
@@ -1,0 +1,21 @@
+import {ACTION_TYPES} from '../actions/index';
+import {ACTIONS_EXCLUDED_FROM_HISTORY, GROUPED_ACTIONS, USER_ACTIONS} from './index';
+
+
+
+describe('reducers/index', () => {
+  describe("Action Groups", () => {
+    it('All actions should be in a group', () => {
+      const actionsInIndex = ACTIONS_EXCLUDED_FROM_HISTORY.concat(
+        GROUPED_ACTIONS,
+        Object.keys(USER_ACTIONS),
+      );
+
+      for (const action of ACTION_TYPES) {
+        expect(actionsInIndex).toContain(action);
+      }
+
+    });
+  });
+});
+

--- a/src/reducers/index.test.ts
+++ b/src/reducers/index.test.ts
@@ -1,8 +1,6 @@
 import {ACTION_TYPES} from '../actions/index';
 import {ACTIONS_EXCLUDED_FROM_HISTORY, GROUPED_ACTIONS, USER_ACTIONS} from './index';
 
-
-
 describe('reducers/index', () => {
   describe("Action Groups", () => {
     it('All actions should be in a group', () => {

--- a/src/reducers/index.ts
+++ b/src/reducers/index.ts
@@ -25,6 +25,7 @@ import {
   SHELF_SPEC_PREVIEW_DISABLE,
 } from '../actions';
 
+import {ActionType} from '../actions';
 import { State } from '../models/index';
 import {configReducer} from './config';
 import {datasetReducer} from './dataset';
@@ -43,10 +44,8 @@ function reducer(state: Readonly<StateBase>, action: Action): StateBase {
 
 /**
  * Exclude these actions from the history completely.
- *
- *
  */
-export const ACTIONS_EXCLUDED_FROM_HISTORY: string[] = [
+export const ACTIONS_EXCLUDED_FROM_HISTORY: ActionType[] = [
   // These actions are automatically re-triggered by some of the shelf components after
   // every state change. Including UNDO/REDO.
   RESULT_RECEIVE,
@@ -67,7 +66,7 @@ export const ACTIONS_EXCLUDED_FROM_HISTORY: string[] = [
  * of the preceding user action if one is available. If none is available it will be put
  * into its own group.
  */
-export const USER_ACTIONS: Object = toSet([
+export const USER_ACTIONS: ActionType[] = [
   // Dataset Actions
   DATASET_URL_REQUEST,
   // Shelf Actions,
@@ -81,7 +80,9 @@ export const USER_ACTIONS: Object = toSet([
   SHELF_SPEC_LOAD,
   SHELF_SPEC_PREVIEW,
   SHELF_SPEC_PREVIEW_DISABLE,
-]);
+];
+
+export const USER_ACTION_INDEX = toSet(USER_ACTIONS);
 
 /**
  * Actions that are to be grouped with actions that precede them.
@@ -92,12 +93,10 @@ export const USER_ACTIONS: Object = toSet([
  * DATASET_URL_RECEIVE,
  */
 
-export const GROUPED_ACTIONS: string[] = [
+export const GROUPED_ACTIONS: ActionType[] = [
   DATASET_INLINE_RECEIVE,
   DATASET_URL_RECEIVE,
 ];
-
-
 
 let _groupId = 0;
 function getNextGroupId(): number {
@@ -108,7 +107,7 @@ function getNextGroupId(): number {
 function groupAction(action: Action, currentState: State, previousHistory: StateWithHistory<State>): any {
   const currentActionType = action.type;
 
-  if (USER_ACTIONS[currentActionType]) {
+  if (USER_ACTION_INDEX[currentActionType]) {
     const nextGroupID = currentActionType + getNextGroupId();
     return nextGroupID;
   } else {

--- a/src/reducers/index.ts
+++ b/src/reducers/index.ts
@@ -7,8 +7,6 @@ import {StateBase} from '../models';
 
 import {SET_CONFIG} from '../actions/config';
 import {
-  DATASET_INLINE_RECEIVE,
-  DATASET_URL_RECEIVE,
   DATASET_URL_REQUEST,
 } from '../actions/dataset';
 import {
@@ -56,7 +54,6 @@ const ACTIONS_EXCLUDED_FROM_HISTORY = [
   // These actions are not (at least at the moment) trigerrable from a user action.
   // They are either initialization options or triggered by an api call when embedding voyager.
   SET_CONFIG,
-  DATASET_INLINE_RECEIVE,
 ];
 
 /**
@@ -69,7 +66,6 @@ const ACTIONS_EXCLUDED_FROM_HISTORY = [
 const USER_ACTIONS = toSet([
   // Dataset Actions
   DATASET_URL_REQUEST,
-  DATASET_URL_RECEIVE,
   // Shelf Actions,
   SHELF_CLEAR,
   SHELF_MARK_CHANGE_TYPE,
@@ -82,6 +78,17 @@ const USER_ACTIONS = toSet([
   SHELF_SPEC_PREVIEW,
   SHELF_SPEC_PREVIEW_DISABLE,
 ]);
+
+/**
+ * Actions that are to be grouped with actions that precede them.
+ *
+ * This list is here for documentation purposes
+ *
+ * DATASET_INLINE_RECEIVE,
+ * DATASET_URL_RECEIVE,
+ */
+
+
 
 let _groupId = 0;
 function getNextGroupId(): number {
@@ -107,6 +114,4 @@ export const rootReducer = undoable(reducer, {
   redoType: REDO,
   groupBy: groupAction,
   filter: excludeAction(ACTIONS_EXCLUDED_FROM_HISTORY),
-  debug: true,
 });
-

--- a/src/reducers/index.ts
+++ b/src/reducers/index.ts
@@ -1,13 +1,37 @@
-import undoable from 'redux-undo';
+import undoable, {excludeAction, StateWithHistory} from 'redux-undo';
 
 import {Action, REDO, UNDO} from '../actions';
 import {HISTORY_LIMIT} from '../constants';
 import {StateBase} from '../models';
 
+import {SET_CONFIG} from '../actions/config';
+import {
+  DATASET_INLINE_RECEIVE,
+  DATASET_URL_RECEIVE,
+  DATASET_URL_REQUEST,
+} from '../actions/dataset';
+import {
+  RESULT_RECEIVE,
+  RESULT_REQUEST,
+} from '../actions/result';
+import {
+  SHELF_CLEAR,
+  SHELF_FIELD_ADD,
+  SHELF_FIELD_AUTO_ADD,
+  SHELF_FIELD_MOVE,
+  SHELF_FIELD_REMOVE,
+  SHELF_FUNCTION_CHANGE,
+  SHELF_MARK_CHANGE_TYPE,
+  SHELF_SPEC_LOAD,
+  SHELF_SPEC_PREVIEW,
+  SHELF_SPEC_PREVIEW_DISABLE,
+} from '../actions/shelf';
+import { State } from '../models/index';
 import {configReducer} from './config';
 import {datasetReducer} from './dataset';
 import {resultReducer} from './result';
 import {shelfReducer} from './shelf';
+
 
 function reducer(state: Readonly<StateBase>, action: Action): StateBase {
   return {
@@ -18,9 +42,64 @@ function reducer(state: Readonly<StateBase>, action: Action): StateBase {
   };
 }
 
+/**
+ * Exclude these actions from the history completely.
+ */
+const excludeActionsInHistory = [DATASET_INLINE_RECEIVE,
+  RESULT_RECEIVE,
+  RESULT_REQUEST,
+  SET_CONFIG,
+];
+
+/**
+ * A list of actions that can be initiated by a user.
+ *
+ * Each of these will start a new 'undo group'. Non-user actions will be put into the group
+ * of the preceding user action if one is available. If none is available it will be put
+ * into its own group.
+ */
+const userActions = [
+  // Dataset Actions
+  DATASET_URL_REQUEST,
+  DATASET_URL_RECEIVE,
+  DATASET_INLINE_RECEIVE,
+  // Shelf Actions,
+  SHELF_CLEAR,
+  SHELF_MARK_CHANGE_TYPE,
+  SHELF_FIELD_ADD,
+  SHELF_FIELD_AUTO_ADD,
+  SHELF_FIELD_REMOVE,
+  SHELF_FIELD_MOVE,
+  SHELF_FUNCTION_CHANGE,
+  SHELF_SPEC_LOAD,
+  SHELF_SPEC_PREVIEW,
+  SHELF_SPEC_PREVIEW_DISABLE,
+];
+
+let _groupId = 0;
+function getNextGroupId(): number {
+  _groupId += 1;
+  return _groupId;
+}
+
+const groupAction = (action: Action, currentState: State, previousHistory: StateWithHistory<State>): any => {
+  const currentActionType = action.type;
+
+  if (userActions.indexOf(currentActionType) >= 0) {
+    const nextGroupID = currentActionType + getNextGroupId();
+    return nextGroupID;
+  } else {
+    const lastGroup = previousHistory.group;
+    return lastGroup;
+  }
+};
+
 export const rootReducer = undoable(reducer, {
   limit: HISTORY_LIMIT,
   undoType: UNDO,
-  redoType: REDO
+  redoType: REDO,
+  groupBy: groupAction,
+  filter: excludeAction(excludeActionsInHistory),
+  debug: true,
 });
 

--- a/src/reducers/index.ts
+++ b/src/reducers/index.ts
@@ -6,14 +6,13 @@ import {HISTORY_LIMIT} from '../constants';
 import {StateBase} from '../models';
 
 import {SET_CONFIG} from '../actions/config';
+
 import {
+  DATASET_INLINE_RECEIVE,
+  DATASET_URL_RECEIVE,
   DATASET_URL_REQUEST,
-} from '../actions/dataset';
-import {
   RESULT_RECEIVE,
   RESULT_REQUEST,
-} from '../actions/result';
-import {
   SHELF_CLEAR,
   SHELF_FIELD_ADD,
   SHELF_FIELD_AUTO_ADD,
@@ -24,7 +23,8 @@ import {
   SHELF_SPEC_LOAD,
   SHELF_SPEC_PREVIEW,
   SHELF_SPEC_PREVIEW_DISABLE,
-} from '../actions/shelf';
+} from '../actions';
+
 import { State } from '../models/index';
 import {configReducer} from './config';
 import {datasetReducer} from './dataset';
@@ -46,7 +46,7 @@ function reducer(state: Readonly<StateBase>, action: Action): StateBase {
  *
  *
  */
-const ACTIONS_EXCLUDED_FROM_HISTORY = [
+export const ACTIONS_EXCLUDED_FROM_HISTORY: string[] = [
   // These actions are automatically re-triggered by some of the shelf components after
   // every state change. Including UNDO/REDO.
   RESULT_RECEIVE,
@@ -54,6 +54,10 @@ const ACTIONS_EXCLUDED_FROM_HISTORY = [
   // These actions are not (at least at the moment) trigerrable from a user action.
   // They are either initialization options or triggered by an api call when embedding voyager.
   SET_CONFIG,
+  // Undo and Redo actions will not be put in the history, but listing them here
+  // allows to check that every action is put in one of these lists.
+  UNDO,
+  REDO,
 ];
 
 /**
@@ -63,7 +67,7 @@ const ACTIONS_EXCLUDED_FROM_HISTORY = [
  * of the preceding user action if one is available. If none is available it will be put
  * into its own group.
  */
-const USER_ACTIONS = toSet([
+export const USER_ACTIONS: Object = toSet([
   // Dataset Actions
   DATASET_URL_REQUEST,
   // Shelf Actions,
@@ -87,6 +91,11 @@ const USER_ACTIONS = toSet([
  * DATASET_INLINE_RECEIVE,
  * DATASET_URL_RECEIVE,
  */
+
+export const GROUPED_ACTIONS: string[] = [
+  DATASET_INLINE_RECEIVE,
+  DATASET_URL_RECEIVE,
+];
 
 
 

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,9 +1,11 @@
 import {applyMiddleware, compose, createStore, Middleware} from 'redux';
 import {createLogger} from 'redux-logger';
 import thunkMiddleware from 'redux-thunk';
+import {StateWithHistory} from 'redux-undo';
 
-import {DEFAULT_STATE} from '../models';
+import { DEFAULT_STATE, StateBase } from '../models';
 import {rootReducer} from '../reducers';
+
 
 const loggerMiddleware = createLogger({
   collapsed: true,
@@ -22,9 +24,17 @@ if (process.env.NODE_ENV !== 'production' && process.env.NODE_ENV !== 'test') {
 }
 
 export function configureStore(initialState = DEFAULT_STATE) {
+  const initialStateWithHistory: StateWithHistory<Readonly<StateBase>> = {
+    past: [],
+    present: initialState,
+    future: [],
+    _latestUnfiltered: null,
+    group: null,
+  };
+
   const store = createStore(
     rootReducer,
-    {past: [], present: initialState, future: []},
+    initialStateWithHistory,
     composeEnhancers(applyMiddleware(...middleware))
   );
   return store;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4902,8 +4902,8 @@ redux-thunk:
   resolved "https://registry.yarnpkg.com/redux-thunk/-/redux-thunk-2.2.0.tgz#e615a16e16b47a19a515766133d1e3e99b7852e5"
 
 redux-undo@beta:
-  version "1.0.0-beta9-7"
-  resolved "https://registry.yarnpkg.com/redux-undo/-/redux-undo-1.0.0-beta9-7.tgz#e3fcc8bc29d8c579f2c13f854287e5af0d8744ae"
+  version "1.0.0-beta9-9-1"
+  resolved "https://registry.yarnpkg.com/redux-undo/-/redux-undo-1.0.0-beta9-9-1.tgz#a2208b30611f44e2cfc5480bc15272b0afb84b1b"
   dependencies:
     redux "^3.5.2"
 


### PR DESCRIPTION
Group actions so that they can be undone/redone in a single step. Remove certain actions from history completely. Closes #349 

@kanitw: A few notes

- This adds a custom groupBy function to creation groups out of actions. However because various components like DatasetSelector and EncodingPane trigger RESULT_RECEIVE, and RESULT_REQUEST every time they are rendered they inject those two back into the history (and destroy `future` in the process). Thus they need to be excluded by a filter.

- I'm not sure if all the actions in https://github.com/vega/voyager/compare/349-undo-redo?expand=1#diff-0c230c2c950beb1f5987a2aed0eeeab3R61 are actually user trigger-able. Please review that list and let me know. I essentially put in all the actions I could find for now.

- Now because we have to filter out RESULT_RECEIVE, and RESULT_REQUEST, it just so happens that with this set of actions, those two were the ones causing the inconsistent state, so we could in theory remove the groupBy function. The question is whether the grouping functionality is more generally useful, or could be useful down the road. Also if we actually should remove some elements from `userAction` then this point will be moot (the grouping function will actually do something the filtering doesn't capture).

Give it a whirl and let me know what you find!