### PR TITLE
fixed previewing shelf cannot be removed

### DIFF
--- a/src/components/plot/index.tsx
+++ b/src/components/plot/index.tsx
@@ -129,6 +129,7 @@ class PlotBase extends React.PureComponent<PlotProps, any> {
   }
 
   private onSpecify() {
+    this.onPreviewMouseLeave();
     const {handleAction, spec} = this.props;
     handleAction({
       type: SHELF_SPEC_LOAD,


### PR DESCRIPTION
bug fix

Previous bug: cannot remove specifying spec shelf. 
![preview-bug](https://user-images.githubusercontent.com/19985016/28234457-a1628868-68b4-11e7-9622-ba011c7bf7c0.gif)
