### PR TITLE
[Need to revise] encoding preview trigger plot re-rendering

### DIFF
--- a/src/components/plot/index.tsx
+++ b/src/components/plot/index.tsx
@@ -43,7 +43,7 @@ class PlotBase extends React.PureComponent<PlotProps, any> {
     this.onSpecify = this.onSpecify.bind(this);
   }
   public render() {
-    const {isPlotListItem, scrollOnHover, showSpecifyButton, spec} = this.props;
+    const {isPlotListItem, showSpecifyButton, spec} = this.props;
 
     return (
       <div styleName={isPlotListItem ? 'plot-list-item-group' : 'plot-group'}>
@@ -61,7 +61,7 @@ class PlotBase extends React.PureComponent<PlotProps, any> {
           </span>
         </div>
         <div
-          styleName={scrollOnHover && this.state.hovered ? 'plot-scroll' : 'plot'}
+          styleName='plot-scroll'
           className="persist-scroll"
           onMouseEnter={this.onMouseEnter}
           onMouseLeave={this.onMouseLeave}

--- a/src/components/plot/plot.scss
+++ b/src/components/plot/plot.scss
@@ -14,11 +14,6 @@
   flex-direction: column;
 }
 
-.plot {
-  overflow: hidden;
-  padding-right: 11px;
-}
-
 .plot-scroll {
   overflow: auto;
   padding-right: 0px;


### PR DESCRIPTION
fixed #308

Note: If I understood this issue correctly, the problem is when hovering over an encoding preview, the plot moves slightly. This is fixed in this PR. 