### PR TITLE
Load header images with web pack loader.

### DIFF
--- a/config/webpack.config.dev.js
+++ b/config/webpack.config.dev.js
@@ -115,7 +115,7 @@ module.exports = {
 
       },
       {
-        test: /\.(ttf|eot|svg)(\?v=[0-9]\.[0-9]\.[0-9])?$/,
+        test: /\.(png|ttf|eot|svg)(\?v=[0-9]\.[0-9]\.[0-9])?$/,
         use: "file-loader"
       }
     ]

--- a/config/webpack.config.prod.js
+++ b/config/webpack.config.prod.js
@@ -167,7 +167,7 @@ module.exports = {
 
       },
       {
-        test: /\.(ttf|eot|svg)(\?v=[0-9]\.[0-9]\.[0-9])?$/,
+        test: /\.(png|ttf|eot|svg)(\?v=[0-9]\.[0-9]\.[0-9])?$/,
         use: "file-loader"
       }
       // ** STOP ** Are you adding a new loader?

--- a/config/webpack.lib.config.js
+++ b/config/webpack.lib.config.js
@@ -96,7 +96,7 @@ module.exports = {
 
       },
       {
-        test: /\.(ttf|eot|svg)(\?v=[0-9]\.[0-9]\.[0-9])?$/,
+        test: /\.(png|ttf|eot|svg)(\?v=[0-9]\.[0-9]\.[0-9])?$/,
         use: "file-loader"
       }
     ]

--- a/src/components/header/index.tsx
+++ b/src/components/header/index.tsx
@@ -3,14 +3,17 @@ import * as CSSModules from 'react-css-modules';
 import {Controls} from './controls';
 import * as styles from './header.scss';
 
+import * as idlLogo from '../../../images/idl-h56.png';
+import * as logo from '../../../images/logo.png';
+
 export class HeaderBase extends React.PureComponent<{}, {}> {
   public render() {
     return (
       <div styleName='header'>
-        <img styleName='voyager-logo' src={'../../../images/logo.png'}/>
+        <img styleName='voyager-logo' src={logo}/>
         <Controls />
         <a styleName='idl-logo' href='https://idl.cs.washington.edu/'>
-          <img src={'../../../images/idl-h56.png'}/>
+          <img src={idlLogo}/>
         </a>
       </div>
     );

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -11,6 +11,11 @@ declare module '*.css' {
   export = content;
 }
 
+declare module '*.png' {
+  const content: any;
+  export = content;
+}
+
 declare module 'font-awesome-webpack' {
   var x: any;
   export = x;


### PR DESCRIPTION
This is a fix for https://github.com/vega/voyager-electron/issues/10, using the webpack will allow the files to be copied over during the build.

ping @kanitw @starry97 