### PR TITLE
[WIP] Add benchmark middleware outside production

### DIFF
--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -5,6 +5,7 @@ import {StateWithHistory} from 'redux-undo';
 
 import {DEFAULT_STATE, StateBase} from '../models';
 import {rootReducer} from '../reducers';
+import {benchmark} from './redux-benchmark';
 
 // Imports to satisfy --declarations build requirements
 // https://github.com/Microsoft/TypeScript/issues/9944
@@ -26,6 +27,11 @@ if (process.env.NODE_ENV !== 'production' && process.env.NODE_ENV !== 'test') {
   composeEnhancers =
     (window as any).__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
   middleware.push(loggerMiddleware);
+}
+
+if (process.env.NODE_ENV !== 'production') {
+  // add timing middleware
+  middleware.push(benchmark);
 }
 
 export function configureStore(initialState = DEFAULT_STATE) {

--- a/src/store/redux-benchmark.ts
+++ b/src/store/redux-benchmark.ts
@@ -1,0 +1,16 @@
+import {Store} from 'redux';
+import {StateWithHistory} from 'redux-undo';
+import {StateBase} from '../models/index';
+
+
+function currentTime() {
+  return Date.now();
+}
+
+export const benchmark = (store: Store<StateWithHistory<Readonly<StateBase>>>) => (next: any) => (action: any) => {
+  const start = currentTime();
+  const result = next( action );
+  const end = currentTime();
+  console.log( `Action with type "${action.type}" took ${( end - start ).toFixed( 2 )} milliseconds.` );
+  return result;
+};


### PR DESCRIPTION
@kanitw - @tafsiri and i were pairing a bit on some ideas. 

Yannick detailed some things that could be benchmarked: https://github.com/vega/voyager/issues/385

this PR adds a tiny timer middleware on the redux store. 
wanted your thoughts on if this is moving in the right direction - or if we need to move this up towards UI rendering. 

additional directions we could take this middleware approach:

* filter so only certain events are recorded
* attempt to name match Result_request/receive - so we can auto aggregate these time values
* attempt to store the timing values themselves back into the datastore - so we could try to download them or view them in voyager. 