### PR TITLE
Use url loader for images (e.g. logo). 

### DIFF
--- a/config/webpack.config.dev.js
+++ b/config/webpack.config.dev.js
@@ -116,7 +116,7 @@ module.exports = {
       },
       {
         test: /\.(png|ttf|eot|svg)(\?v=[0-9]\.[0-9]\.[0-9])?$/,
-        use: "file-loader"
+        use: "url-loader"
       }
     ]
   },

--- a/config/webpack.config.prod.js
+++ b/config/webpack.config.prod.js
@@ -168,7 +168,7 @@ module.exports = {
       },
       {
         test: /\.(png|ttf|eot|svg)(\?v=[0-9]\.[0-9]\.[0-9])?$/,
-        use: "file-loader"
+        use: "url-loader"
       }
       // ** STOP ** Are you adding a new loader?
       // Remember to add the new extension(s) to the "url" loader exclusion list.

--- a/config/webpack.lib.config.js
+++ b/config/webpack.lib.config.js
@@ -97,7 +97,7 @@ module.exports = {
       },
       {
         test: /\.(png|ttf|eot|svg)(\?v=[0-9]\.[0-9]\.[0-9])?$/,
-        use: "file-loader"
+        use: "url-loader"
       }
     ]
   },


### PR DESCRIPTION
Closes https://github.com/vega/voyager-electron/issues/16

<img width="691" alt="screen shot 2017-07-27 at 3 16 16 pm" src="https://user-images.githubusercontent.com/26408/28688072-a38a6488-72de-11e7-9e3b-f4a7178c3ba3.png">

Embedding the image as a data:uri should avoid any path issues in embedding contexts.
