### PR TITLE
Add more padding to plot icons; change color to be consistent

### DIFF
--- a/src/components/plot/bookmarkbutton.scss
+++ b/src/components/plot/bookmarkbutton.scss
@@ -1,9 +1,16 @@
+@import './plot.scss';
+
 .bookmark-alert {
-    color: #fff;
-    background-color: #38425d;
-    padding: 8px;
-    font-size: 14px;
-    line-height: 18px;
-    min-width: 150px;
-    border-radius: 3px;
+  color: #fff;
+  background-color: #38425d;
+  padding: 8px;
+  font-size: 14px;
+  line-height: 18px;
+  min-width: 150px;
+  border-radius: 3px;
+}
+
+.bookmark-command-selected {
+  @extend .command;
+  color: #0c96d0;
 }

--- a/src/components/plot/bookmarkbutton.tsx
+++ b/src/components/plot/bookmarkbutton.tsx
@@ -42,7 +42,7 @@ export class BookmarkButtonBase extends React.PureComponent<BookmarkProps, Bookm
       >
         <i
           className="fa fa-bookmark command-bookmark"
-          style = {{color: bookmarkColor, paddingLeft: '3px'}}
+          style = {{color: bookmarkColor, paddingLeft: '12px', cursor: 'pointer'}}
           onClick = {this.onBookmarkClick}
         />
 

--- a/src/components/plot/bookmarkbutton.tsx
+++ b/src/components/plot/bookmarkbutton.tsx
@@ -33,7 +33,7 @@ export class BookmarkButtonBase extends React.PureComponent<BookmarkProps, Bookm
   }
 
   public render() {
-    const bookmarkColor = (this.isBookmarked()) ? '#0c96d0' : '#aaa';
+    const styleName = (this.isBookmarked()) ? 'bookmark-command-selected' : 'command';
 
     return (
       <TetherComponent
@@ -41,9 +41,9 @@ export class BookmarkButtonBase extends React.PureComponent<BookmarkProps, Bookm
           targetAttachment="bottom left"
       >
         <i
-          className="fa fa-bookmark command-bookmark"
-          style = {{color: bookmarkColor, paddingLeft: '12px', cursor: 'pointer'}}
-          onClick = {this.onBookmarkClick}
+          className="fa fa-bookmark"
+          styleName={styleName}
+          onClick={this.onBookmarkClick}
         />
 
         {
@@ -100,7 +100,6 @@ export class BookmarkButtonBase extends React.PureComponent<BookmarkProps, Bookm
       }
     });
   }
-
 }
 
 export const BookmarkButton = CSSModules(BookmarkButtonBase, styles);

--- a/src/components/plot/index.tsx
+++ b/src/components/plot/index.tsx
@@ -196,7 +196,7 @@ export class PlotBase extends React.PureComponent<PlotProps, any> {
   private specifyButton() {
     return <i
       className="fa fa-server"
-      styleName="specify-button"
+      styleName="specify-command"
       onClick={this.onSpecify}
       onMouseEnter={this.onPreviewMouseEnter}
       onMouseLeave={this.onPreviewMouseLeave}
@@ -233,7 +233,7 @@ export class PlotBase extends React.PureComponent<PlotProps, any> {
       <CopyToClipboard
         onCopy={this.copied.bind(this)}
         text={JSON.stringify(this.props.spec, null, 2)}>
-        <span><i className='fa fa-clipboard' styleName='copy-button'/></span>
+        <span><i className='fa fa-clipboard' styleName='command'/></span>
       </CopyToClipboard>
     );
   }

--- a/src/components/plot/index.tsx
+++ b/src/components/plot/index.tsx
@@ -208,7 +208,6 @@ export class PlotBase extends React.PureComponent<PlotProps, any> {
       fieldInfos: this.props.fieldInfos,
       spec: this.props.spec
     };
-
     return (
       <BookmarkButton
         bookmark = {this.props.bookmark}

--- a/src/components/plot/plot.scss
+++ b/src/components/plot/plot.scss
@@ -39,8 +39,12 @@
 
 .command {
   cursor: pointer;
-  margin-left: 20px;
+  margin-left: 10px;
   color: #aaa;
+}
+
+.command:hover {
+  color: #72c1d5;
 }
 
 .specify-command {

--- a/src/components/plot/plot.scss
+++ b/src/components/plot/plot.scss
@@ -37,13 +37,14 @@
   float: right;
 }
 
-.bookmark-button, .copy-button {
-  cursor: pointer;
-  margin-left: 4px;
-}
-
 .specify-button {
   transform: scaleX(-1);
+}
+
+.specify-button, .copy-button {
+  cursor: pointer;
+  margin-left: 12px;
+  color: #aaa;
 }
 
 .copied {

--- a/src/components/plot/plot.scss
+++ b/src/components/plot/plot.scss
@@ -37,14 +37,15 @@
   float: right;
 }
 
-.specify-button {
-  transform: scaleX(-1);
+.command {
+  cursor: pointer;
+  margin-left: 20px;
+  color: #aaa;
 }
 
-.specify-button, .copy-button {
-  cursor: pointer;
-  margin-left: 12px;
-  color: #aaa;
+.specify-command {
+  @extend .command;
+  transform: scaleX(-1);
 }
 
 .copied {


### PR DESCRIPTION
Related to #482. 

It does not change the size of icons, because the FontAwesome icons we use have different sizes. Adding more spaces make them look better. 
 