### PR TITLE
Fix size issue in Data Selector modal

### DIFF
--- a/src/components/data-pane/data-selector.tsx
+++ b/src/components/data-pane/data-selector.tsx
@@ -50,6 +50,7 @@ export class DataSelectorBase extends React.PureComponent<DataSelectorProps, any
          onRequestClose={this.closeModal}
          contentLabel="Data Selector"
          styleName="modal"
+         className="voyager"
        >
           <div styleName='modal-header'>
             <a styleName='modal-close' onClick={this.closeModal}>close</a>


### PR DESCRIPTION
#478 

- Add `className='voyager'` to the Modal to resize everything back to normal.
