### PR TITLE
Fix `copy-to-clipboard` plot command hitbox

### DIFF
--- a/src/components/plot/index.tsx
+++ b/src/components/plot/index.tsx
@@ -247,7 +247,7 @@ export class PlotBase extends React.PureComponent<PlotProps, PlotState> {
       <CopyToClipboard
         onCopy={this.copied.bind(this)}
         text={JSON.stringify(this.props.spec, null, 2)}>
-        <span><i className='fa fa-clipboard' styleName='command'/></span>
+        <i className='fa fa-clipboard' styleName='command'/>
       </CopyToClipboard>
     );
   }


### PR DESCRIPTION
- Remove `<span>` surrounding the clipboard icon since it caused the clipboard's hitbox to extend onto the bookmark icon to its left. This would cause the spec to be copied when the right side of the bookmark icon was clicked (shown below).

Before:
![image](https://user-images.githubusercontent.com/17525561/28800848-8584aa3e-7603-11e7-8536-1a813c2d30eb.png)
