### PR TITLE
Fix moving encoding field

### DIFF
--- a/src/components/encoding-pane/encoding-shelf.tsx
+++ b/src/components/encoding-pane/encoding-shelf.tsx
@@ -30,7 +30,7 @@ export interface EncodingShelfPropsBase extends ActionHandler<ShelfEncodingActio
 
   fieldDef: ShelfFieldDef;
 
-  schema?: Schema;
+  schema: Schema;
 }
 
 interface EncodingShelfProps extends EncodingShelfPropsBase, EncodingShelfDropTargetProps {};

--- a/src/components/encoding-pane/encoding-shelf.tsx
+++ b/src/components/encoding-pane/encoding-shelf.tsx
@@ -1,3 +1,4 @@
+import {Schema} from 'compassql/build/src/schema';
 import {isWildcard} from 'compassql/build/src/wildcard';
 import * as React from 'react';
 import * as CSSModules from 'react-css-modules';
@@ -28,6 +29,8 @@ export interface EncodingShelfPropsBase extends ActionHandler<ShelfEncodingActio
   id: ShelfId;
 
   fieldDef: ShelfFieldDef;
+
+  schema?: Schema;
 }
 
 interface EncodingShelfProps extends EncodingShelfPropsBase, EncodingShelfDropTargetProps {};
@@ -69,7 +72,7 @@ class EncodingShelfBase extends React.PureComponent<EncodingShelfProps, {}> {
   }
 
   private field() {
-    const {id, fieldDef} = this.props;
+    const {id, fieldDef, schema} = this.props;
     const renderFunctionPicker = fieldDef.type === 'quantitative' || fieldDef.type === 'temporal';
 
     const functionPicker = renderFunctionPicker ?
@@ -84,6 +87,7 @@ class EncodingShelfBase extends React.PureComponent<EncodingShelfProps, {}> {
           fieldDef={fieldDef}
           filterHide={true}
           isPill={true}
+          schema={schema}
           popupComponent={functionPicker}
           onRemove={this.onRemove.bind(this)}
           parentId={{type: FieldParentType.ENCODING_SHELF, id: id}}

--- a/src/components/encoding-pane/index.tsx
+++ b/src/components/encoding-pane/index.tsx
@@ -100,13 +100,14 @@ class EncodingPanelBase extends React.PureComponent<EncodingPanelProps, {}> {
   private encodingShelf(channel: Channel) {
     // This one can't be wildcard, thus we use VL's Channel, not our ShelfChannel
 
-    const {handleAction, spec, specPreview} = this.props;
+    const {handleAction, spec, specPreview, schema} = this.props;
     const {encoding} = specPreview || spec;
     return (
       <EncodingShelf
         key={channel}
         id={{channel}}
         fieldDef={encoding[channel]}
+        schema={schema}
         handleAction={handleAction}
       />
     );

--- a/src/components/encoding-pane/index.tsx
+++ b/src/components/encoding-pane/index.tsx
@@ -124,7 +124,7 @@ class EncodingPanelBase extends React.PureComponent<EncodingPanelProps, {}> {
 
   private wildcardShelf(index: number) {
     const {anyEncodings} = this.props.spec;
-    const {handleAction} = this.props;
+    const {handleAction, schema} = this.props;
 
     const id = {
       channel: SHORT_WILDCARD,
@@ -135,6 +135,7 @@ class EncodingPanelBase extends React.PureComponent<EncodingPanelProps, {}> {
       <EncodingShelf
         key={index}
         id={id}
+        schema={schema}
         fieldDef={anyEncodings[index]}
         handleAction={handleAction}
       />

--- a/src/components/field/index.tsx
+++ b/src/components/field/index.tsx
@@ -278,7 +278,7 @@ const fieldSource: DragSourceSpec<FieldProps> = {
   beginDrag(props): DraggedFieldIdentifier {
     const {fieldDef, parentId, schema} = props;
     let domain;
-    if (!isWildcard(fieldDef.field)) {
+    if (!isWildcard(fieldDef.field) && fieldDef.field !== '*') {
       domain = schema.domain({field: fieldDef.field});
     }
     const filter = getFilter(fieldDef, domain);


### PR DESCRIPTION
Previously there was a bug preventing the encoding field being moved to another shelf, now this is fixed. 