### PR TITLE
Disable UI test on Travis temporarily

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,8 @@ node_js:
 script:
   - npm run build
   - npm run codecov
-  - npm run test:ui
+  # Disable UI test until we fidn a solution to the core dump issue
+  # - npm run test:ui
   - npm run lint
 after_success:
   - bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
This means that we should always make sure to run `npm run test` locally before submitting a PR.