### PR TITLE
Fix bookmark notes css

### DIFF
--- a/src/components/plot/index.tsx
+++ b/src/components/plot/index.tsx
@@ -73,6 +73,7 @@ export class PlotBase extends React.PureComponent<PlotProps, PlotState> {
     if (this.props.bookmark.dict[specKey]) {
       notesDiv = (
         <textarea
+          styleName='note'
           type='text'
           placeholder={'notes'}
           value={this.props.bookmark.dict[specKey].note}

--- a/src/components/plot/plot.scss
+++ b/src/components/plot/plot.scss
@@ -56,3 +56,10 @@
 .copied {
   font-size: 12px;
 }
+
+.note {
+  min-height: 60px;
+  resize: none;
+  border-color: #d3d3d3;
+  width: 100%;
+}


### PR DESCRIPTION
Make bookmark notes style consistent with the old app.
Fix #518 
![image](https://user-images.githubusercontent.com/19985016/29049867-49accc8c-7b8d-11e7-8da0-26ac4fe0677a.png)
