### PR TITLE
Fix function picker so `-` displays as checked on initial load and click

### DIFF
--- a/src/components/encoding-pane/function-picker.tsx
+++ b/src/components/encoding-pane/function-picker.tsx
@@ -28,18 +28,24 @@ export class FunctionPickerBase extends React.PureComponent<FunctionPickerProps,
 
     const {fn, type} = fieldDefParts;
     const supportedFns = getSupportedFunction(type);
-    const radios = supportedFns.map(f => (
-      <label styleName="func-label" key={f || '-'}>
-        <input
-          type="radio"
-          value={f || '-'}
-          checked={f === fn}
-          onChange={this.onFunctionChange}
-        />
-        {' '}
-        {f || '-'}
-      </label>
-    ));
+    const radios = supportedFns.map(f => {
+      if (f === undefined && fn !== undefined) {
+        f = '-';
+      }
+
+      return (
+        <label styleName="func-label" key={f || '-'}>
+          <input
+            type="radio"
+            value={f || '-'}
+            checked={f === fn}
+            onChange={this.onFunctionChange}
+          />
+          {' '}
+          {f || '-'}
+        </label>
+      );
+    });
 
     if (isWildcard(fn)) {
       throw new Error('Wildcard function not supported yet');


### PR DESCRIPTION
Fix function selector radios so that it shows `-` as selected when it's clicked

![image](https://user-images.githubusercontent.com/17525561/29330742-0d27bb46-81af-11e7-89a3-4d203f90ee0f.png)
