### PR TITLE
Add `manualSpecificationOnly` flag to VoyagerConfig

### DIFF
--- a/src/components/data-pane/index.tsx
+++ b/src/components/data-pane/index.tsx
@@ -17,7 +17,7 @@ export class DataPanelBase extends React.PureComponent<DataPanelProps, {}> {
   public render() {
     const {name} = this.props.data;
     const fieldCount = this.props.data.schema.fieldSchemas.length;
-    const {showDataSourceSelector} = this.props.config;
+    const {showDataSourceSelector, manualSpecificationOnly} = this.props.config;
 
     const fields = fieldCount > 0 ? (
       <div styleName="data-pane-section">
@@ -25,7 +25,7 @@ export class DataPanelBase extends React.PureComponent<DataPanelProps, {}> {
         <FieldList/>
       </div>) : null;
 
-    const wildcardFields = fieldCount > 0 ? (
+    const wildcardFields = !manualSpecificationOnly && fieldCount > 0 ? (
       <div styleName="data-pane-section">
         <h3>Wildcard Fields</h3>
         <PresetWildcardFieldList/>

--- a/src/components/data-pane/index.tsx
+++ b/src/components/data-pane/index.tsx
@@ -25,12 +25,12 @@ export class DataPanelBase extends React.PureComponent<DataPanelProps, {}> {
         <FieldList/>
       </div>) : null;
 
-    const wildcardFields = !manualSpecificationOnly && fieldCount > 0 ? (
+    const wildcardFields = !manualSpecificationOnly && fieldCount > 0 && (
       <div styleName="data-pane-section">
         <h3>Wildcard Fields</h3>
         <PresetWildcardFieldList/>
       </div>
-    ) : null;
+    );
     return (
       <div className="pane" styleName="data-pane">
         <h2 styleName="data-pane-title">Data</h2>

--- a/src/components/encoding-pane/index.tsx
+++ b/src/components/encoding-pane/index.tsx
@@ -52,8 +52,8 @@ class EncodingPanelBase extends React.PureComponent<EncodingPanelProps, {}> {
     const positionShelves = ['x', 'y'].map(this.encodingShelf, this);
     const facetShelves = ['row', 'column'].map(this.encodingShelf, this);
     const nonPositionShelves = ['size', 'color', 'shape', 'detail', 'text'].map(this.encodingShelf, this);
-    const wildcardShelves = !manualSpecificationOnly ? (
-      <div>
+    const wildcardShelvesGroup = !manualSpecificationOnly ? (
+      <div styleName="shelf-group">
         <h3>Wildcard Shelves</h3>
         {[...anyEncodings.map((_, i) => i),
           -1 // map the empty placeholder to -1
@@ -92,9 +92,7 @@ class EncodingPanelBase extends React.PureComponent<EncodingPanelProps, {}> {
         </div>
 
         {/* TODO: correctly highlight field in the wildcard */}
-        <div styleName="shelf-group">
-          {wildcardShelves}
-        </div>
+        {wildcardShelvesGroup}
 
         <div styleName="shelf-group">
           <h3>Filter</h3>

--- a/src/components/encoding-pane/index.tsx
+++ b/src/components/encoding-pane/index.tsx
@@ -52,14 +52,14 @@ class EncodingPanelBase extends React.PureComponent<EncodingPanelProps, {}> {
     const positionShelves = ['x', 'y'].map(this.encodingShelf, this);
     const facetShelves = ['row', 'column'].map(this.encodingShelf, this);
     const nonPositionShelves = ['size', 'color', 'shape', 'detail', 'text'].map(this.encodingShelf, this);
-    const wildcardShelvesGroup = !manualSpecificationOnly ? (
+    const wildcardShelvesGroup = !manualSpecificationOnly && (
       <div styleName="shelf-group">
         <h3>Wildcard Shelves</h3>
         {[...anyEncodings.map((_, i) => i),
           -1 // map the empty placeholder to -1
         ].map(this.wildcardShelf, this)}
       </div>
-    ) : null;
+    );
 
     return (
       <div className="pane" styleName="encoding-pane">

--- a/src/components/encoding-pane/index.tsx
+++ b/src/components/encoding-pane/index.tsx
@@ -11,8 +11,9 @@ import {createDispatchHandler} from '../../actions/redux-action';
 import {ResultAsyncAction} from '../../actions/result';
 import {ShelfAction, SPEC_CLEAR} from '../../actions/shelf';
 import {ShelfUnitSpec, State} from '../../models';
+import {VoyagerConfig} from '../../models/config';
 import {ShelfFieldDef} from '../../models/shelf';
-import {selectDataset, selectShelf, selectShelfPreview} from '../../selectors';
+import {selectConfig, selectDataset, selectShelf, selectShelfPreview} from '../../selectors';
 import {selectSchemaFieldDefs} from '../../selectors/index';
 import * as styles from './encoding-pane.scss';
 import {EncodingShelf} from './encoding-shelf';
@@ -31,6 +32,8 @@ interface EncodingPanelProps extends ActionHandler<ShelfAction | ResultAsyncActi
   schema: Schema;
 
   fieldDefs: ShelfFieldDef[];
+
+  config: VoyagerConfig;
 }
 
 class EncodingPanelBase extends React.PureComponent<EncodingPanelProps, {}> {
@@ -43,15 +46,20 @@ class EncodingPanelBase extends React.PureComponent<EncodingPanelProps, {}> {
 
   public render() {
     const {specPreview, spec} = this.props;
+    const {manualSpecificationOnly} = this.props.config;
     const {anyEncodings} = specPreview || spec;
 
     const positionShelves = ['x', 'y'].map(this.encodingShelf, this);
     const facetShelves = ['row', 'column'].map(this.encodingShelf, this);
     const nonPositionShelves = ['size', 'color', 'shape', 'detail', 'text'].map(this.encodingShelf, this);
-    const wildcardShelves = [
-      ...anyEncodings.map((_, i) => i),
-      -1 // map the empty placeholder to -1
-    ].map(this.wildcardShelf, this);
+    const wildcardShelves = !manualSpecificationOnly ? (
+      <div>
+        <h3>Wildcard Shelves</h3>
+        {[...anyEncodings.map((_, i) => i),
+          -1 // map the empty placeholder to -1
+        ].map(this.wildcardShelf, this)}
+      </div>
+    ) : null;
 
     return (
       <div className="pane" styleName="encoding-pane">
@@ -85,7 +93,6 @@ class EncodingPanelBase extends React.PureComponent<EncodingPanelProps, {}> {
 
         {/* TODO: correctly highlight field in the wildcard */}
         <div styleName="shelf-group">
-          <h3>Wildcard Shelves</h3>
           {wildcardShelves}
         </div>
 
@@ -169,7 +176,8 @@ export const EncodingPane = connect(
       filters: selectShelf(state).spec.filters,
       schema: selectDataset(state).schema,
       fieldDefs: selectSchemaFieldDefs(state),
-      specPreview: selectShelfPreview(state).spec
+      specPreview: selectShelfPreview(state).spec,
+      config: selectConfig(state)
     };
   },
   createDispatchHandler<ShelfAction>()

--- a/src/components/view-pane/index.tsx
+++ b/src/components/view-pane/index.tsx
@@ -59,12 +59,12 @@ class ViewPaneBase extends React.PureComponent<ViewPaneProps, {}> {
     const {isQuerySpecific, plots} = this.props;
     const {manualSpecificationOnly} = this.props.config;
 
-    const relatedViews = !manualSpecificationOnly ? (
+    const relatedViews = !manualSpecificationOnly && (
       <div className="pane" styleName="view-pane-related-views">
         <h2>Related Views</h2>
         <RelatedViews/>
       </div>
-    ) : null;
+    );
 
     if (isQuerySpecific) {
       return (

--- a/src/components/view-pane/index.tsx
+++ b/src/components/view-pane/index.tsx
@@ -9,9 +9,10 @@ import {SHELF_AUTO_ADD_COUNT_CHANGE, SHELF_GROUP_BY_CHANGE} from '../../actions/
 import {SPEC_FIELD_PROP_CHANGE} from '../../actions/shelf/spec';
 import {State} from '../../models';
 import {Bookmark} from '../../models/bookmark';
+import {VoyagerConfig} from '../../models/config';
 import {ResultPlot} from '../../models/result';
 import {SHELF_GROUP_BYS, ShelfGroupBy} from '../../models/shelf/index';
-import {selectBookmark, selectMainSpec, selectPlotList} from '../../selectors';
+import {selectBookmark, selectConfig, selectMainSpec, selectPlotList} from '../../selectors';
 import {selectResultLimit} from '../../selectors/result';
 import {selectAutoAddCount, selectDefaultGroupBy, selectIsQuerySpecific, selectShelf} from '../../selectors/shelf';
 import {Plot} from '../plot';
@@ -30,6 +31,7 @@ export interface ViewPaneProps extends ActionHandler<ShelfAction> {
 
   groupBy: ShelfGroupBy;
   defaultGroupBy: ShelfGroupBy;
+  config: VoyagerConfig;
 }
 
 const NO_PLOT_MESSAGE = `No specified visualization yet. ` +
@@ -55,6 +57,14 @@ class ViewPaneBase extends React.PureComponent<ViewPaneProps, {}> {
 
   public render() {
     const {isQuerySpecific, plots} = this.props;
+    const {manualSpecificationOnly} = this.props.config;
+
+    const relatedViews = !manualSpecificationOnly ? (
+      <div className="pane" styleName="view-pane-related-views">
+        <h2>Related Views</h2>
+        <RelatedViews/>
+      </div>
+    ) : null;
 
     if (isQuerySpecific) {
       return (
@@ -63,11 +73,7 @@ class ViewPaneBase extends React.PureComponent<ViewPaneProps, {}> {
             <h2>Specified View</h2>
             {this.renderSpecifiedView()}
           </div>
-
-          <div className="pane" styleName="view-pane-related-views">
-            <h2>Related Views</h2>
-            <RelatedViews/>
-          </div>
+          {relatedViews}
         </div>
       );
     } else if (plots) {
@@ -180,7 +186,8 @@ export const ViewPane = connect(
       mainLimit: selectResultLimit.main(state),
       autoAddCount: selectAutoAddCount(state),
       groupBy: selectShelf(state).groupBy,
-      defaultGroupBy: selectDefaultGroupBy(state)
+      defaultGroupBy: selectDefaultGroupBy(state),
+      config: selectConfig(state)
     };
   },
   createDispatchHandler<ShelfAction>()

--- a/src/models/config.ts
+++ b/src/models/config.ts
@@ -1,9 +1,11 @@
 export interface VoyagerConfig {
   showDataSourceSelector?: boolean;
   serverUrl?: string | null;
+  manualSpecificationOnly?: boolean;
 };
 
 export const DEFAULT_VOYAGER_CONFIG: VoyagerConfig = {
   showDataSourceSelector: true,
-  serverUrl: null
+  serverUrl: null,
+  manualSpecificationOnly: true
 };

--- a/src/models/config.ts
+++ b/src/models/config.ts
@@ -7,5 +7,5 @@ export interface VoyagerConfig {
 export const DEFAULT_VOYAGER_CONFIG: VoyagerConfig = {
   showDataSourceSelector: true,
   serverUrl: null,
-  manualSpecificationOnly: true
+  manualSpecificationOnly: false
 };

--- a/src/queries/index.ts
+++ b/src/queries/index.ts
@@ -51,6 +51,10 @@ export function dispatchQueries(store: Store<State>, query: Query) {
   const isQuerySpecific = selectIsQuerySpecific(state);
   store.dispatch(resultRequest('main', query, null));
 
+  if (state.persistent.config.manualSpecificationOnly) {
+    return;
+  }
+
   if (isQueryEmpty) {
     store.dispatch(relatedViewResultRequest(histograms, query));
   } else {


### PR DESCRIPTION
Fix issue #624 

- [x] Add `manualSpecificationOnly` flag to VoyagerConfig
- [x] When `manualSpecificationOnly` is `true`, don't dispatch actions for related views queries
- [x] The flag defaults to `false`
- [x] UI adjustments
  - [x] When the flag is `true`, hide wildcards and related views
![screen shot 2017-08-18 at 4 45 12 pm](https://user-images.githubusercontent.com/822034/29481717-51e23d92-8439-11e7-905c-4cbb97b10481.png)

  - [x] When the flag is `false`, show wildcards and related views as usual
![screen shot 2017-08-18 at 4 49 59 pm](https://user-images.githubusercontent.com/822034/29481732-82674f5c-8439-11e7-8ca4-c7976dbc7193.png)
