### PR TITLE
Fix style for encoding fields with long names

### DIFF
--- a/src/components/encoding-pane/encoding-shelf.scss
+++ b/src/components/encoding-pane/encoding-shelf.scss
@@ -21,6 +21,7 @@ $pill-height: 22px;
   box-sizing: border-box;
   border: 1px solid transparent;
   border-radius: 3px;
+  width: 168px;
   height: $pill-height;
 }
 


### PR DESCRIPTION
Fix #585
![image](https://user-images.githubusercontent.com/19985016/29542751-fcb74f4c-8690-11e7-8776-28c1d4b5553e.png)
