### PR TITLE
Set `transpileOnly: true` in `ts-loader` to remove nested build folder created in postbuild

### DIFF
--- a/config/webpack.config.lib.js
+++ b/config/webpack.config.lib.js
@@ -45,7 +45,15 @@ module.exports = {
 
   module: {
     rules: [
-      { test: /\.tsx?$/, use: "ts-loader" },
+      {
+        test: /\.tsx?$/,
+        use: {
+          loader: "ts-loader",
+          options: {
+            transpileOnly: true
+          }
+        },
+      },
       // All output '.js' files will have any sourcemaps re-processed by 'source-map-loader'.
       { test: /\.js$/, use: "source-map-loader", enforce: "pre" },
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6330,19 +6330,9 @@ vega-hierarchy@1:
     vega-dataflow "2"
     vega-util "1"
 
-vega-lite@2.0.0-beta.19:
+vega-lite@2.0.0-beta.19, vega-lite@^2.0.0-beta.3:
   version "2.0.0-beta.19"
   resolved "https://registry.yarnpkg.com/vega-lite/-/vega-lite-2.0.0-beta.19.tgz#75bfcee41f2734d928b2449d025b2a5ae00b5044"
-  dependencies:
-    json-stable-stringify "^1.0.1"
-    tslib "^1.7.1"
-    vega-event-selector "^2.0.0"
-    vega-util "^1.5.0"
-    yargs "^8.0.2"
-
-vega-lite@^2.0.0-beta.3:
-  version "2.0.0-beta.14"
-  resolved "https://registry.yarnpkg.com/vega-lite/-/vega-lite-2.0.0-beta.14.tgz#a643e0a528806106bc6234c4c48c9de6bd545225"
   dependencies:
     json-stable-stringify "^1.0.1"
     tslib "^1.7.1"
@@ -6418,13 +6408,13 @@ vega-tooltip@^0.4.2:
     vega "^3.0.0-beta.31"
     vega-lite "^2.0.0-beta.3"
 
-vega-util@1, vega-util@^1.2:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/vega-util/-/vega-util-1.3.0.tgz#cf338e0d8210b9d369ce8cfa6727c39a89d4fe9f"
-
-vega-util@^1.1, vega-util@^1.4, vega-util@^1.5.0:
+vega-util@1, vega-util@^1.1, vega-util@^1.4, vega-util@^1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/vega-util/-/vega-util-1.5.0.tgz#05fcec83557be38de5328b54ad2a7a0597740cc0"
+
+vega-util@^1.2:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/vega-util/-/vega-util-1.3.0.tgz#cf338e0d8210b9d369ce8cfa6727c39a89d4fe9f"
 
 vega-view@1:
   version "1.2.4"


### PR DESCRIPTION
Fix #668 

Setting `transpileOnly: true` in lib config's `ts-loader` removes the nested build folder created when we run `webpack.config.lib` in our postbuild script. Normally setting `transpileOnly: true` is a bad idea because it leaves us without type checking, but we always `tsc` prior to `webpack.config.lib` in postbuild which takes care of type checking.