### PR TITLE
Remove png from url-loader to fix corrupting image files

### DIFF
--- a/config/webpack.config.prod.js
+++ b/config/webpack.config.prod.js
@@ -169,7 +169,7 @@ module.exports = {
 
       },
       {
-        test: /\.(png|ttf|eot|svg)(\?v=[0-9]\.[0-9]\.[0-9])?$/,
+        test: /\.(ttf|eot|svg)(\?v=[0-9]\.[0-9]\.[0-9])?$/,
         use: "url-loader"
       }
       // ** STOP ** Are you adding a new loader?


### PR DESCRIPTION
Fix #660 - Our logos are back!
- Remove redundant `png` from url-loader as we were running them through url-loader twice

![image](https://user-images.githubusercontent.com/17525561/29990141-c092521a-8f2c-11e7-8d41-6fc88041ab3f.png)
