### PR TITLE
Fix setState warning when uploading a dataset

### DIFF
--- a/src/components/data-selector/index.tsx
+++ b/src/components/data-selector/index.tsx
@@ -226,7 +226,6 @@ export class DataSelectorBase extends React.PureComponent<DataSelectorProps, Dat
       }
 
       handleAction(datasetLoad(name, {values, format}));
-      this.closeModal();
     };
 
     reader.readAsText(file);


### PR DESCRIPTION
Fix #666 

Turns out we don't need `this.closeModal()` to close the modal when we upload a dataset.