### PR TITLE
Add optional config when embedding voyager as library

### DIFF
--- a/config/webpack.config.dev.js
+++ b/config/webpack.config.dev.js
@@ -132,9 +132,9 @@ module.exports = {
   // assume a corresponding global variable exists and use that instead.
   // This is important because it allows us to avoid bundling all of our
   // dependencies, which allows browsers to cache those libraries between builds.
+
+  // Since its a local dev build we don't need to mark anything external.
   externals: {
-    "react": "React",
-    "react-dom": "ReactDOM"
   },
   plugins: [
     new webpack.HotModuleReplacementPlugin(),

--- a/config/webpack.config.dev.js
+++ b/config/webpack.config.dev.js
@@ -133,8 +133,9 @@ module.exports = {
   // This is important because it allows us to avoid bundling all of our
   // dependencies, which allows browsers to cache those libraries between builds.
 
-  // Since its a local dev build we don't need to mark anything external.
   externals: {
+    "react": "React",
+    "react-dom": "ReactDOM"
   },
   plugins: [
     new webpack.HotModuleReplacementPlugin(),

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "build": "node scripts/build.js",
     "postbuild": "npm run tsc && npm run build:lib",
     "build:lib": "webpack --config config/webpack.config.lib.js",
-    "watch": "webpack -d --watch",
+    "watch": "webpack --config config/webpack.config.dev.js -d --watch",
     "clean": "find -E dist  -regex '.*\\.(js|js.map|d.ts)' -delete",
     "lint": "tslint -c tslint.json 'src/**/*.ts' 'src/**/*.tsx'",
     "lint-fix": "npm run lint -- --fix",

--- a/src/components/app-root/index.tsx
+++ b/src/components/app-root/index.tsx
@@ -6,8 +6,10 @@ import {connect} from 'react-redux';
 import {ClipLoader} from 'react-spinners';
 import * as SplitPane from 'react-split-pane';
 import {SPINNER_COLOR} from '../../constants';
+import {VoyagerConfig} from '../../models/config';
 import {Dataset} from '../../models/dataset';
 import {State} from '../../models/index';
+import {selectConfig} from '../../selectors';
 import {selectDataset} from '../../selectors/dataset';
 import '../app.scss';
 import {DataPane} from '../data-pane/index';
@@ -20,11 +22,15 @@ import {ViewPane} from '../view-pane/index';
 
 export interface AppRootProps {
   dataset: Dataset;
+  config: VoyagerConfig;
 }
 
 class AppRootBase extends React.PureComponent<AppRootProps, {}> {
   public render() {
-    const {dataset} = this.props;
+    const {dataset, config} = this.props;
+    const {embedProps = {}} = config;
+    const hideHeader = embedProps.hideHeader || false;
+    const hideFooter = embedProps.hideFooter || false;
     let bottomPane, footer;
     if (!dataset.isLoading) {
       if (!dataset.data) {
@@ -39,13 +45,15 @@ class AppRootBase extends React.PureComponent<AppRootProps, {}> {
             </SplitPane>
           </SplitPane>
         );
-        footer = <Footer/>;
+        if (!hideFooter) {
+          footer = <Footer/>;
+        }
       }
     }
     return (
       <div className="voyager">
         <LogPane/>
-        <Header/>
+        {!hideHeader ? <Header/> : null}
         <ClipLoader color={SPINNER_COLOR} loading={dataset.isLoading}/>
         {bottomPane}
         {footer}
@@ -57,7 +65,8 @@ class AppRootBase extends React.PureComponent<AppRootProps, {}> {
 export const AppRoot = connect(
   (state: State) => {
     return {
-      dataset: selectDataset(state)
+      dataset: selectDataset(state),
+      config: selectConfig(state)
     };
   }
 )(DragDropContext(HTML5Backend)(AppRootBase));

--- a/src/components/app-root/index.tsx
+++ b/src/components/app-root/index.tsx
@@ -28,7 +28,7 @@ export interface AppRootProps {
 class AppRootBase extends React.PureComponent<AppRootProps, {}> {
   public render() {
     const {dataset, config} = this.props;
-    const {hideHeader = false, hideFooter = false} = config;
+    const {hideHeader, hideFooter} = config;
     let bottomPane, footer;
     if (!dataset.isLoading) {
       if (!dataset.data) {

--- a/src/components/app-root/index.tsx
+++ b/src/components/app-root/index.tsx
@@ -28,9 +28,7 @@ export interface AppRootProps {
 class AppRootBase extends React.PureComponent<AppRootProps, {}> {
   public render() {
     const {dataset, config} = this.props;
-    const {embedProps = {}} = config;
-    const hideHeader = embedProps.hideHeader || false;
-    const hideFooter = embedProps.hideFooter || false;
+    const {hideHeader = false, hideFooter = false} = config;
     let bottomPane, footer;
     if (!dataset.isLoading) {
       if (!dataset.data) {
@@ -53,7 +51,7 @@ class AppRootBase extends React.PureComponent<AppRootProps, {}> {
     return (
       <div className="voyager">
         <LogPane/>
-        {!hideHeader ? <Header/> : null}
+        {!hideHeader && <Header/>}
         <ClipLoader color={SPINNER_COLOR} loading={dataset.isLoading}/>
         {bottomPane}
         {footer}

--- a/src/lib-voyager.tsx
+++ b/src/lib-voyager.tsx
@@ -44,7 +44,10 @@ export class Voyager {
       this.container = container;
     }
 
-    this.config = Object.assign({}, DEFAULT_VOYAGER_CONFIG, config);
+    this.config = {
+      ...DEFAULT_VOYAGER_CONFIG,
+      ...config
+    };
     this.data = data;
     this.init();
   }

--- a/src/lib-voyager.tsx
+++ b/src/lib-voyager.tsx
@@ -18,7 +18,7 @@ import {isString} from 'vega-lite/build/src/util';
 import * as vlSchema from 'vega-lite/build/vega-lite-schema.json';
 import {App} from './components/app';
 import {State} from './models';
-import {VoyagerConfig} from './models/config';
+import {DEFAULT_VOYAGER_CONFIG, VoyagerConfig} from './models/config';
 import {fromSerializable, SerializableState, toSerializable} from './models/index';
 import {configureStore} from './store';
 
@@ -44,7 +44,7 @@ export class Voyager {
       this.container = container;
     }
 
-    this.config = config;
+    this.config = Object.assign({}, DEFAULT_VOYAGER_CONFIG, config);
     this.data = data;
     this.init();
   }

--- a/src/models/config.ts
+++ b/src/models/config.ts
@@ -1,11 +1,20 @@
+export interface EmbedProps {
+  hideHeader?: boolean;
+  hideFooter?: boolean;
+};
 export interface VoyagerConfig {
   showDataSourceSelector?: boolean;
   serverUrl?: string | null;
   manualSpecificationOnly?: boolean;
+  embedProps?: EmbedProps;
 };
 
 export const DEFAULT_VOYAGER_CONFIG: VoyagerConfig = {
   showDataSourceSelector: true,
   serverUrl: null,
-  manualSpecificationOnly: false
+  manualSpecificationOnly: false,
+  embedProps: {
+    hideHeader: false,
+    hideFooter: false
+  }
 };

--- a/src/models/config.ts
+++ b/src/models/config.ts
@@ -1,20 +1,15 @@
-export interface EmbedProps {
-  hideHeader?: boolean;
-  hideFooter?: boolean;
-};
 export interface VoyagerConfig {
   showDataSourceSelector?: boolean;
   serverUrl?: string | null;
   manualSpecificationOnly?: boolean;
-  embedProps?: EmbedProps;
+  hideHeader?: boolean;
+  hideFooter?: boolean;
 };
 
 export const DEFAULT_VOYAGER_CONFIG: VoyagerConfig = {
   showDataSourceSelector: true,
   serverUrl: null,
   manualSpecificationOnly: false,
-  embedProps: {
-    hideHeader: false,
-    hideFooter: false
-  }
+  hideHeader: false,
+  hideFooter: false
 };


### PR DESCRIPTION
- Add default embed configuration to `VoyagerConfig`.
- Currently it supports hiding header and footer.
- This configuration basically gives an option to not render the header and footer when embedding voyager in another application.
- By default the header and footer are rendered. So existing setup requires no change.

Created this as part of the discussion that went in this Issue: https://github.com/vega/voyager/issues/673

#### Note:
- Have not modified any docs. Not sure if this is the final implementation or if there is a simpler way to do this.