### PR TITLE
Avoids uglifying library when running test build #702

### DIFF
--- a/scripts/jest-ui.js
+++ b/scripts/jest-ui.js
@@ -17,6 +17,9 @@ config.output.publicPath = '/lib-test/';
 config.output.path = path.resolve(__dirname, '../lib-test');
 config.output.filename = '[name].js';
 config.externals = {};
+
+// UI test build runs with NODE_ENV === 'test' and React expects this to be production if minified
+// Thus do not use UglifyJS for UI test
 config.plugins = config.plugins.filter(plugin => !(plugin instanceof webpack.optimize.UglifyJsPlugin));
 
 

--- a/scripts/jest-ui.js
+++ b/scripts/jest-ui.js
@@ -17,6 +17,7 @@ config.output.publicPath = '/lib-test/';
 config.output.path = path.resolve(__dirname, '../lib-test');
 config.output.filename = '[name].js';
 config.externals = {};
+config.plugins = config.plugins.filter(plugin => !(plugin instanceof webpack.optimize.UglifyJsPlugin));
 
 
 const basedir = path.resolve(__dirname, '../src');
@@ -30,6 +31,7 @@ config.entry = tests
     carry[key] = path.resolve(basedir, key);
     return carry;
   }, {});
+
 
 const compiler = webpack(config);
 compiler.run(function() {});


### PR DESCRIPTION
#### Issue:
- React warns users when a minified build of react is run in a non-production environment
- Recently we started using UgilifyJS webpack plugin to uglify final library build. However since we used the same webpack config it was minifying development version of react which was causing the issue.(UI test build runs with `NODE_ENV === 'test'` and react expects this to be `production` if minified).

#### Fix:
- Avoids uglifying code when running ui test build.

Fixes https://github.com/vega/voyager/issues/702