### PR TITLE
Add getSpec handler to lib-voyager

### DIFF
--- a/src/lib-voyager.test.ui.tsx
+++ b/src/lib-voyager.test.ui.tsx
@@ -225,7 +225,7 @@ describe('lib-voyager', () => {
       }, DEFAULT_TIMEOUT_LENGTH);
     });
 
-    it('getSpec returns Vega-Lite spec', done => {
+    it('getSpec returns Vega-Lite spec without inline data', done => {
       setTimeout(() => {
         try {
           const voyagerInst = CreateVoyager(container, undefined, undefined);
@@ -257,7 +257,7 @@ describe('lib-voyager', () => {
 
           setTimeout(() => {
             try {
-              const retrievedSpec = voyagerInst.getSpec();
+              const retrievedSpec = voyagerInst.getSpec(false);
               expect(retrievedSpec).toEqual({
                 data: {
                   name: 'source'
@@ -297,6 +297,84 @@ describe('lib-voyager', () => {
 
       }, DEFAULT_TIMEOUT_LENGTH);
     });
+  });
+
+  it('getSpec returns Vega-Lite spec with inline data', done => {
+    setTimeout(() => {
+      try {
+        const voyagerInst = CreateVoyager(container, undefined, undefined);
+        const spec: Object = {
+          "$schema": "https://vega.github.io/schema/vega-lite/v2.json",
+          "data": {
+            "values": [
+              {"date": "24-Apr-07", "close": "93.24"},
+              {"date": "25-Apr-07", "close": "95.35"},
+              {"date": "26-Apr-07", "close": "98.84"},
+              {"date": "27-Apr-07", "close": "99.92"}
+            ]
+          },
+          "mark": "bar",
+          "encoding": {
+            "x": {
+              "bin": true,
+              "field": "close",
+              "type": "quantitative"
+            },
+            "y": {
+              "aggregate": "count",
+              "field": "*",
+              "type": "quantitative"
+            }
+          }
+        };
+        voyagerInst.setSpec(spec);
+
+        setTimeout(() => {
+          try {
+            const retrievedSpec = voyagerInst.getSpec(true);
+            expect(retrievedSpec).toEqual({
+              data: {
+                "values": [
+                  {"date": "24-Apr-07", "close": "93.24"},
+                  {"date": "25-Apr-07", "close": "95.35"},
+                  {"date": "26-Apr-07", "close": "98.84"},
+                  {"date": "27-Apr-07", "close": "99.92"}
+                ]
+              },
+              mark: 'bar',
+              encoding: {
+                "x": {
+                  "bin": true,
+                  "field": "close",
+                  "type": "quantitative"
+                },
+                "y": {
+                  "aggregate": "count",
+                  "field": "*",
+                  "type": "quantitative"
+                }
+              },
+              config: {
+                overlay: {
+                  line: true
+                },
+                scale: {
+                  useUnaggregatedDomain: true
+                }
+              }
+            });
+
+            done();
+          } catch (err) {
+            done.fail(err);
+          }
+        }, DEFAULT_TIMEOUT_LENGTH);
+
+      } catch (err) {
+        done.fail(err);
+      }
+
+    }, DEFAULT_TIMEOUT_LENGTH);
   });
 
 });

--- a/src/lib-voyager.test.ui.tsx
+++ b/src/lib-voyager.test.ui.tsx
@@ -225,7 +225,7 @@ describe('lib-voyager', () => {
       }, DEFAULT_TIMEOUT_LENGTH);
     });
 
-    it('getSpec returns Vega-Lite spec without inline data', done => {
+    it('getSpec with includeData = false returns Vega Lite spec without data', done => {
       setTimeout(() => {
         try {
           const voyagerInst = CreateVoyager(container, undefined, undefined);
@@ -299,7 +299,7 @@ describe('lib-voyager', () => {
     });
   });
 
-  it('getSpec returns Vega-Lite spec with inline data', done => {
+  it('getSpec with includeData = true returns Vega-Lite spec with data', done => {
     setTimeout(() => {
       try {
         const voyagerInst = CreateVoyager(container, undefined, undefined);

--- a/src/lib-voyager.test.ui.tsx
+++ b/src/lib-voyager.test.ui.tsx
@@ -224,5 +224,79 @@ describe('lib-voyager', () => {
 
       }, DEFAULT_TIMEOUT_LENGTH);
     });
+
+    it('getSpec returns Vega-Lite spec', done => {
+      setTimeout(() => {
+        try {
+          const voyagerInst = CreateVoyager(container, undefined, undefined);
+          const spec: Object = {
+            "$schema": "https://vega.github.io/schema/vega-lite/v2.json",
+            "data": {
+              "values": [
+                {"date": "24-Apr-07", "close": "93.24"},
+                {"date": "25-Apr-07", "close": "95.35"},
+                {"date": "26-Apr-07", "close": "98.84"},
+                {"date": "27-Apr-07", "close": "99.92"}
+              ]
+            },
+            "mark": "bar",
+            "encoding": {
+              "x": {
+                "bin": true,
+                "field": "close",
+                "type": "quantitative"
+              },
+              "y": {
+                "aggregate": "count",
+                "field": "*",
+                "type": "quantitative"
+              }
+            }
+          };
+          voyagerInst.setSpec(spec);
+
+          setTimeout(() => {
+            try {
+              const retrievedSpec = voyagerInst.getSpec();
+              expect(retrievedSpec).toEqual({
+                data: {
+                  name: 'source'
+                },
+                mark: 'bar',
+                encoding: {
+                  "x": {
+                    "bin": true,
+                    "field": "close",
+                    "type": "quantitative"
+                  },
+                  "y": {
+                    "aggregate": "count",
+                    "field": "*",
+                    "type": "quantitative"
+                  }
+                },
+                config: {
+                  overlay: {
+                    line: true
+                  },
+                  scale: {
+                    useUnaggregatedDomain: true
+                  }
+                }
+              });
+
+              done();
+            } catch (err) {
+              done.fail(err);
+            }
+          }, DEFAULT_TIMEOUT_LENGTH);
+
+        } catch (err) {
+          done.fail(err);
+        }
+
+      }, DEFAULT_TIMEOUT_LENGTH);
+    });
   });
+
 });

--- a/src/lib-voyager.tsx
+++ b/src/lib-voyager.tsx
@@ -20,6 +20,7 @@ import {App} from './components/app';
 import {State} from './models';
 import {DEFAULT_VOYAGER_CONFIG, VoyagerConfig} from './models/config';
 import {fromSerializable, SerializableState, toSerializable} from './models/index';
+import { selectData } from './selectors/index';
 import {selectMainSpec} from './selectors/result';
 import {configureStore} from './store';
 
@@ -156,8 +157,13 @@ export class Voyager {
    *
    * @memberof Voyager
    */
-  public getSpec(): FacetedCompositeUnitSpec {
-    return selectMainSpec(this.store.getState());
+  public getSpec(includeData: boolean): FacetedCompositeUnitSpec {
+    const spec = selectMainSpec(this.store.getState());
+    if (includeData) {
+      spec.data = selectData(this.store.getState());
+    }
+
+    return spec;
   }
 
   /**

--- a/src/lib-voyager.tsx
+++ b/src/lib-voyager.tsx
@@ -20,6 +20,7 @@ import {App} from './components/app';
 import {State} from './models';
 import {DEFAULT_VOYAGER_CONFIG, VoyagerConfig} from './models/config';
 import {fromSerializable, SerializableState, toSerializable} from './models/index';
+import {selectMainSpec} from './selectors/result';
 import {configureStore} from './store';
 
 
@@ -145,6 +146,18 @@ export class Voyager {
    */
   public getApplicationState(): SerializableState {
     return toSerializable(this.store.getState());
+  }
+
+  /**
+   *
+   * Gets Vega-Lite spec of current specified view
+   *
+   * @returns {Readonly<Spec>}
+   *
+   * @memberof Voyager
+   */
+  public getSpec(): FacetedCompositeUnitSpec {
+    return selectMainSpec(this.store.getState());
   }
 
   /**

--- a/src/lib-voyager.tsx
+++ b/src/lib-voyager.tsx
@@ -20,7 +20,7 @@ import {App} from './components/app';
 import {State} from './models';
 import {DEFAULT_VOYAGER_CONFIG, VoyagerConfig} from './models/config';
 import {fromSerializable, SerializableState, toSerializable} from './models/index';
-import { selectData } from './selectors/index';
+import {selectData} from './selectors/dataset';
 import {selectMainSpec} from './selectors/result';
 import {configureStore} from './store';
 
@@ -160,7 +160,10 @@ export class Voyager {
   public getSpec(includeData: boolean): FacetedCompositeUnitSpec {
     const spec = selectMainSpec(this.store.getState());
     if (includeData) {
-      spec.data = selectData(this.store.getState());
+      return {
+        ...spec,
+        data: selectData(this.store.getState()),
+      };
     }
 
     return spec;


### PR DESCRIPTION
Add `getSpec` to lib-voyager to export Vega-Lite spec for current specified view.

`getSpec` accepts a boolean value indicating whether or not to attach data payload (inline) in request. 

Fix #746 

