### PR TITLE
Make view and runView() protected in VegaLite class 

### DIFF
--- a/src/components/vega-lite/index.tsx
+++ b/src/components/vega-lite/index.tsx
@@ -25,7 +25,7 @@ export interface VegaLiteState {
 const CHART_REF = 'chart';
 
 export class VegaLite extends React.PureComponent<VegaLiteProps, VegaLiteState> {
-  private view: vega.View;
+  protected view: vega.View;
   private size: {width: number, height: number};
 
   private mountTimeout: number;
@@ -151,6 +151,13 @@ export class VegaLite extends React.PureComponent<VegaLiteProps, VegaLiteState> 
     }
   }
 
+  protected runView() {
+    try {
+      this.view.run();
+    } catch (err) {
+      this.props.logger.error(err);
+    }
+  }
 
   private bindData() {
     const {data, spec} = this.props;
@@ -160,14 +167,6 @@ export class VegaLite extends React.PureComponent<VegaLiteProps, VegaLiteState> 
             .remove(() => true) // remove previous data
             .insert(data.values)
       );
-    }
-  }
-
-  private runView() {
-    try {
-      this.view.run();
-    } catch (err) {
-      this.props.logger.error(err);
     }
   }
 


### PR DESCRIPTION
because I want to extend this `VegaLite` class in my own app so that whenever `runView()` is called, the vega view will be updated in my app state and I can run further consistency analysis on the rendered view.

- [x] Change `view` from `private` to `protected`
- [x] Change `runView()` from `private` to `protected`
- [x] Move `runView()` up because protected methods should come before private methods