### PR TITLE
Make state generic for other apps to extend

### DIFF
--- a/src/actions/index.ts
+++ b/src/actions/index.ts
@@ -19,6 +19,7 @@ export * from './config';
 export * from './dataset';
 export * from './log';
 export * from './redux-action';
+export * from './related-views';
 export * from './reset';
 export * from './result';
 export * from './shelf';

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -39,10 +39,12 @@ export interface UndoableStateBase extends UndoableStateBaseWithoutDataset {
 /**
  * Application state (wrapped with redux-undo's StateWithHistory interface).
  */
-export interface State {
+export interface GenericState<U extends UndoableStateBase> {
   persistent: PersistentState;
-  undoable: StateWithHistory<UndoableStateBase>;
+  undoable: StateWithHistory<U>;
 };
+
+export type State = GenericState<UndoableStateBase>;
 
 export const DEFAULT_UNDOABLE_STATE_BASE: UndoableStateBase = {
   customWildcardFields: DEFAULT_CUSTOM_WILDCARD_FIELDS,

--- a/src/reducers/index.ts
+++ b/src/reducers/index.ts
@@ -7,8 +7,10 @@ import {DEFAULT_STATE, DEFAULT_UNDOABLE_STATE_BASE, PlotTabState} from '../model
 
 import {SET_CONFIG} from '../actions/config';
 
-// tslint:disable-next-line:no-unused-variable
+// tslint:disable:no-unused-variable
 import {Action as BaseReduxAction, combineReducers, Reducer} from 'redux';
+import {GenericState} from '../models';
+// tslint:enable:no-unused-variable
 
 import {
   BOOKMARK_ADD_PLOT,
@@ -96,7 +98,7 @@ const persistentStateToReset: ResetIndex<PersistentState> = {
   shelfPreview: true
 };
 
-const persistentReducer = makeResetReducer(
+export const persistentReducer = makeResetReducer(
   combineReducers<PersistentState>({
     bookmark: bookmarkReducer,
     config: configReducer,
@@ -245,7 +247,7 @@ function groupAction(action: Action, currentState: UndoableStateBase,
 /**
  * Whether to reset a particular property of the undoable state during RESET action
  */
-const undoableStateToReset: ResetIndex<UndoableStateBase> = {
+export const undoableStateToReset: ResetIndex<UndoableStateBase> = {
   customWildcardFields: true,
   dataset: true,
   tab: true
@@ -257,7 +259,7 @@ const combinedUndoableReducer = combineReducers<UndoableStateBase>({
   tab: tabReducer,
 });
 
-const undoableReducerBase = makeResetReducer(
+export const undoableReducerBase = makeResetReducer(
   (state: Readonly<UndoableStateBase> = DEFAULT_UNDOABLE_STATE_BASE, action: Action): UndoableStateBase => {
     switch (action.type) {
       // SPEC_FIELD_AUTO_ADD is a special case that requires schema as a parameter

--- a/src/selectors/dataset.ts
+++ b/src/selectors/dataset.ts
@@ -1,6 +1,7 @@
 // tslint:disable:no-unused-variable
 import {StateWithHistory} from 'redux-undo';
 import {Selector} from 'reselect/src/reselect';
+import {GenericState, UndoableStateBase} from '../models';
 import {ResultPlot} from '../models/result';
 // tslint:enable:no-unused-variable
 

--- a/src/selectors/index.ts
+++ b/src/selectors/index.ts
@@ -1,8 +1,11 @@
 // Imports to satisfy --declarations build requirements
 // https://github.com/Microsoft/TypeScript/issues/9944
 
-// tslint:disable-next-line:no-unused-variable
+// tslint:disable:no-unused-variable
 import {StateWithHistory} from 'redux-undo';
+import {GenericState, UndoableStateBase} from '../models';
+// tslint:enable:no-unused-variable
+
 import {createSelector} from 'reselect';
 import {InlineData} from 'vega-lite/build/src/data';
 import {State} from '../models';
@@ -15,7 +18,6 @@ import {ShelfPreview} from '../models/shelf-preview';
 import {ShelfFilter, toPredicateFunction} from '../models/shelf/filter';
 import {selectData} from './dataset';
 import {selectFilters} from './shelf';
-// tslint:disable-next-line:no-unused-variable
 
 export * from './dataset';
 export * from './result';

--- a/src/selectors/result.ts
+++ b/src/selectors/result.ts
@@ -4,6 +4,7 @@ import {BoxPlotDef} from 'vega-lite/build/src/compositemark/boxplot';
 import {EncodingWithFacet} from 'vega-lite/build/src/encoding';
 import {MarkDef} from 'vega-lite/build/src/mark';
 import {FacetedCompositeUnitSpec, GenericUnitSpec, isUnitSpec} from 'vega-lite/build/src/spec';
+import {GenericState, UndoableStateBase} from '../models/index';
 // tslint:enable:no-unused-variable
 
 import {createSelector} from 'reselect';

--- a/src/selectors/shelf.ts
+++ b/src/selectors/shelf.ts
@@ -1,7 +1,7 @@
 // tslint:disable:no-unused-variable
 import {StateWithHistory} from 'redux-undo';
 import {OneOfFilter, RangeFilter} from 'vega-lite/build/src/filter';
-import {State} from '../models/index';
+import {GenericState, State, UndoableStateBase} from '../models/index';
 // tslint:enable:no-unused-variable
 
 import {Query} from 'compassql/build/src/query/query';

--- a/src/selectors/tab.ts
+++ b/src/selectors/tab.ts
@@ -1,6 +1,10 @@
 import {createSelector} from 'reselect';
 import {PlotTabState, State, Tab} from '../models';
 
+// tslint:disable:no-unused-variable
+import {GenericState, UndoableStateBase} from '../models';
+// tslint:enable:no-unused-variable
+
 export const selectTab = (state: State): Tab => state.undoable.present.tab;
 
 export const selectActiveTabID = createSelector(

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,7 +1,9 @@
 // Imports to satisfy --declarations build requirements
 // https://github.com/Microsoft/TypeScript/issues/9944
-// tslint:disable-next-line:no-unused-variable
+// tslint:disable:no-unused-variable
 import {Store} from 'redux';
+import {GenericState, UndoableStateBase} from '../models/index';
+// tslint:enable:no-unused-variable
 
 import {applyMiddleware, compose, createStore, Middleware, StoreEnhancer} from 'redux';
 import {createActionLog} from 'redux-action-log';


### PR DESCRIPTION
- [x] Make state generic
  - [x] Make `undoable` state generic because I want to extend this state in my app

- [x] Import the generic states and disable tslint `no-unused-variable` in files that use the generic states (This is a fix of https://github.com/Microsoft/TypeScript/issues/9944)

- [x] Export `persistentReducer`, `undoableReducerBase`,  and `undoableStateToReset` because I'm using them from my app

- [x] Export `related-views` actions because I need to know all Voyager actions in my app

- [x] Make lint and test pass. (Run `npm run lint` and `npm run test`.)

Thank you!!!