### PR TITLE
Add viewRunAfterCallback in VegaLite props

### DIFF
--- a/src/components/vega-lite/index.tsx
+++ b/src/components/vega-lite/index.tsx
@@ -16,6 +16,8 @@ export interface VegaLiteProps {
   logger: Logger;
 
   data: InlineData;
+
+  viewRunAfter?: (view: vega.View) => any;
 }
 
 export interface VegaLiteState {
@@ -166,6 +168,9 @@ export class VegaLite extends React.PureComponent<VegaLiteProps, VegaLiteState> 
   private runView() {
     try {
       this.view.run();
+      if (this.props.viewRunAfter) {
+        this.view.runAfter(this.props.viewRunAfter);
+      }
     } catch (err) {
       this.props.logger.error(err);
     }

--- a/typings/vega.d.ts
+++ b/typings/vega.d.ts
@@ -9,6 +9,7 @@ declare module 'vega' {
     public finalize(): void;
     public hover(): View;
     public run(): View;
+    public runAfter(callback: (view: View) => any): void;
     public change(name: string, changeset: any): View;
     public changeset(): any;
     public data(name: string): object[];


### PR DESCRIPTION
- [x] Add an optional prop called `viewRunAfterCallback` to the VegaLite component so that I can get the vega view from this component after it has been run. 