### PR TITLE
Stop query compassQL when related-views tab hidden

### DIFF
--- a/src/queries/index.ts
+++ b/src/queries/index.ts
@@ -51,10 +51,9 @@ export function dispatchQueries(store: Store<State>, query: Query) {
   const isQuerySpecific = selectIsQuerySpecific(state);
   store.dispatch(resultRequest('main', query, null));
 
-  if (state.persistent.config.manualSpecificationOnly) {
+  if (state.persistent.config.manualSpecificationOnly || state.persistent.relatedViews.isHidden) {
     return;
   }
-
   if (isQueryEmpty) {
     store.dispatch(relatedViewResultRequest(histograms, query));
   } else {

--- a/src/store/listener.ts
+++ b/src/store/listener.ts
@@ -2,12 +2,14 @@ import {Query} from 'compassql/build/src/query/query';
 import {Store} from 'redux';
 import {Data} from 'vega-lite/build/src/data';
 import {State} from '../models/index';
+import {RelatedViews} from '../models/related-views';
 import {dispatchQueries} from '../queries/index';
-import {selectData, selectQuery} from '../selectors/index';
+import {selectData, selectQuery, selectRelatedViews} from '../selectors/index';
 
 export function createQueryListener(store: Store<State>) {
   let data: Data;
   let query: Query;
+  let relatedViews: RelatedViews;
   return () => {
     const state = store.getState();
     const previousQuery = query;
@@ -16,12 +18,16 @@ export function createQueryListener(store: Store<State>) {
     const previousData = data;
     data = selectData(state);
 
+    const previousRelatedViews = relatedViews;
+    relatedViews = selectRelatedViews(state);
+
+
     if (!data) {
       return;
     }
 
     // Check if either query or data has changed, need to submit a new query.
-    if (previousQuery !== query || previousData !== data) {
+    if (previousQuery !== query || previousData !== data || previousRelatedViews !== relatedViews) {
       dispatchQueries(store, query);
     }
   };


### PR DESCRIPTION
Stop compassQL for querying related views when related-views toggle mode is on.

![voyagerhidetoggle](https://user-images.githubusercontent.com/9298611/36943865-a11d12ea-1f45-11e8-82a4-973ab47f73c1.gif)


