### PR TITLE
Add yarn.lock to publish script for future releases

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -8,4 +8,3 @@ codecov.yml
 tsconfig.json
 tsconfig.*.json
 tslint.json
-yarn.lock

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -36,6 +36,9 @@ npm run build
 # add the compiled files, commit and tag!
 git add build/ -f
 
+# add yarn.lock for node_module consistency
+git add yarn.lock
+
 git commit -m "release $version $gitsha"
 git tag -am "Release v$version." "v$version"
 


### PR DESCRIPTION
Add the yarn.lock to the publish script for future npm releases. 

The yarn.lock file will ensure that packages that use datavoyager npm package get precisely the same dependencies.

