### PR TITLE
Fix closing customizer bug

### DIFF
--- a/src/components/encoding-pane/encoding-shelf.tsx
+++ b/src/components/encoding-pane/encoding-shelf.tsx
@@ -152,7 +152,7 @@ class EncodingShelfBase extends React.PureComponent<
 
   protected onRemove() {
     const {id, handleAction} = this.props;
-
+    this.toggleCustomizer();
     handleAction({
       type: SPEC_FIELD_REMOVE,
       payload: id


### PR DESCRIPTION
Fix #775 
Only allow property-editor pane to be opened when `fieldDef` is defined. 
![customizerbuffix](https://user-images.githubusercontent.com/9298611/38776921-ed00ceb6-4053-11e8-8054-2a3d134b58e1.gif)

