### PR TITLE
Copy .scss files from src to build folder 

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -44,6 +44,9 @@ measureFileSizesBeforeBuild(paths.appBuild).then(previousFileSizes => {
 
   // Copy data folder
   copyDataFolder();
+
+  // Copy scss files from /src to /build
+  copyScss();
 });
 
 // Print out errors
@@ -100,5 +103,19 @@ function build(previousFileSizes) {
 function copyDataFolder() {
   fs.copySync(path.resolve(__dirname, '../node_modules/vega-datasets'), path.resolve(paths.appBuild, 'datasets'), {
     dereference: true,
+  });
+}
+
+// Copy scss files from /src/components/ to /build/components/ for external app to use Voyager components
+function copyScss() {
+  fs.copySync(path.resolve(__dirname, '../src/components'), path.resolve(__dirname, '../build/components'), {
+    dereference: true,
+    filter: (path) => {
+      if (fs.lstatSync(path).isDirectory()) {
+        return true;
+      } else {
+        return path.endsWith('.scss');
+      }
+    }
   });
 }

--- a/src/components/vega-lite/index.tsx
+++ b/src/components/vega-lite/index.tsx
@@ -16,6 +16,8 @@ export interface VegaLiteProps {
   logger: Logger;
 
   data: InlineData;
+
+  viewRunAfter?: (view: vega.View) => any;
 }
 
 export interface VegaLiteState {
@@ -166,6 +168,9 @@ export class VegaLite extends React.PureComponent<VegaLiteProps, VegaLiteState> 
   private runView() {
     try {
       this.view.run();
+      if (this.props.viewRunAfter) {
+        this.view.runAfter(this.props.viewRunAfter);
+      }
     } catch (err) {
       this.props.logger.error(err);
     }

--- a/typings/vega.d.ts
+++ b/typings/vega.d.ts
@@ -9,6 +9,7 @@ declare module 'vega' {
     public finalize(): void;
     public hover(): View;
     public run(): View;
+    public runAfter(callback: (view: View) => any): void;
     public change(name: string, changeset: any): View;
     public changeset(): any;
     public data(name: string): object[];


### PR DESCRIPTION
Please merge https://github.com/vega/voyager/pull/776 first

This PR fix https://github.com/vega/voyager/issues/739

I add a `copyScss()` function in `scripts/build.js` to copy the style files from `/src` to `/build` folder. This allows external apps to reuse Voyager components with style.

