### PR TITLE
More Custom Encoding

### DIFF
--- a/src/components/encoding-pane/encoding-shelf.tsx
+++ b/src/components/encoding-pane/encoding-shelf.tsx
@@ -86,7 +86,7 @@ class EncodingShelfBase extends React.PureComponent<
             attachment="top left"
             targetAttachment="bottom left"
           >
-            {(fieldDef && !isWildcardChannelId(id) && (id.channel === 'x' || id.channel === 'y')) ?
+            {(fieldDef && !isWildcardChannelId(id)) ?
               <span onClick={this.toggleCustomizer} ref={this.fieldHandler}>
                 {channelName}{' '} <i className={'fa fa-caret-down'}/>
               </span> :
@@ -168,7 +168,7 @@ class EncodingShelfBase extends React.PureComponent<
 
   protected onRemove() {
     const {id, handleAction} = this.props;
-    this.toggleCustomizer();
+    this.closePopup();
     handleAction({
       type: SPEC_FIELD_REMOVE,
       payload: id
@@ -219,7 +219,8 @@ class EncodingShelfBase extends React.PureComponent<
   }
 
   private handleClickOutside(e: any) {
-    if (this.fieldCustomizer && (this.fieldCustomizer.contains(e.target) || this.encodingShelf.contains(e.target))) {
+    if (this.fieldCustomizer && this.encodingShelf && (this.fieldCustomizer.contains(e.target) ||
+      this.encodingShelf.contains(e.target))) {
       return;
     }
     this.closePopup();

--- a/src/components/encoding-pane/field-customizer.scss
+++ b/src/components/encoding-pane/field-customizer.scss
@@ -19,7 +19,7 @@
     font-size: 11px !important; // cannot access react-form's css attributes, so have to use important
     padding-right: 10px;
     text-align: left;
-    width: 60px;
+    width: 75px;
   }
 
   ul {

--- a/src/components/encoding-pane/field-customizer.scss
+++ b/src/components/encoding-pane/field-customizer.scss
@@ -2,7 +2,7 @@
   background-color: #eee;
   border-bottom: 5px solid #eee;
   border-radius: 3px;
-  width: 225px;
+  width: 250px;
 
   fieldset {
     border: 0;

--- a/src/components/encoding-pane/field-customizer.tsx
+++ b/src/components/encoding-pane/field-customizer.tsx
@@ -22,46 +22,48 @@ export class FieldCustomizerBase extends React.PureComponent<FieldCustomizerProp
   public render() {
     const {shelfId, handleAction, fieldDef} = this.props;
     const propertyGroupIndex = getFieldPropertyGroupIndex(shelfId, fieldDef);
-    const keys = Object.keys(propertyGroupIndex);
+    const keys = propertyGroupIndex ? Object.keys(propertyGroupIndex) : undefined;
     return (
       <div styleName='field-customizer'>
-        <Tabs>
-          <TabList>
-            {
-              keys.map((encodingType, i) => {
-                return (
-                  <Tab key={i}>{encodingType}</Tab>
-                );
-              })
-            }
-          </TabList>
-          <div>
-            {
-              keys.map((encodingType, i) => {
-                const customProps: CustomProp[] = propertyGroupIndex[encodingType];
-                return (
-                  <TabPanel key={encodingType + i}>
-                    {
-                      customProps.map(customizableProp => {
-                        const {prop, nestedProp} = customizableProp;
-                        return (
-                          <PropertyEditor
-                            key={prop + '_' + nestedProp}
-                            prop={prop}
-                            nestedProp={nestedProp}
-                            shelfId={shelfId}
-                            fieldDef={fieldDef}
-                            handleAction={handleAction}
-                            propTab={encodingType}
-                          />
-                        );
-                      })
-                    }
-                  </TabPanel>
-                );
-              })}
-          </div>
-        </Tabs>
+        {keys && (
+          <Tabs>
+            <TabList>
+              {
+                keys.map((encodingType, i) => {
+                  return (
+                    <Tab key={'tab' + i}>{encodingType}</Tab>
+                  );
+                })
+              }
+            </TabList>
+            <div>
+              {
+                keys.map((encodingType, i) => {
+                  const customProps: CustomProp[] = propertyGroupIndex[encodingType];
+                  return (
+                    <TabPanel key={'tabPanel' + encodingType + i}>
+                      {
+                        customProps.map(customizableProp => {
+                          const {prop, nestedProp} = customizableProp;
+                          return (
+                            <PropertyEditor
+                              key={prop + '_' + nestedProp + i}
+                              prop={prop}
+                              nestedProp={nestedProp}
+                              shelfId={shelfId}
+                              fieldDef={fieldDef}
+                              handleAction={handleAction}
+                              propTab={encodingType}
+                            />
+                          );
+                        })
+                      }
+                    </TabPanel>
+                  );
+                })}
+            </div>
+          </Tabs>
+        )}
       </div>
     );
   }

--- a/src/components/encoding-pane/property-editor-schema.ts
+++ b/src/components/encoding-pane/property-editor-schema.ts
@@ -1,8 +1,12 @@
 import {ExpandedType} from 'compassql/build/src/query/expandedtype';
 import {Channel} from 'vega-lite/build/src/channel';
+import {contains} from 'vega-lite/build/src/util';
 import * as vlSchema from 'vega-lite/build/vega-lite-schema.json';
 import {ShelfFieldDef, ShelfId} from '../../models/shelf/spec';
 
+// ------------------------------------------------------------------------------
+// Schema Interfaces
+// ------------------------------------------------------------------------------
 export interface SchemaProperties {
   [key: string]: SchemaProperty;
 }
@@ -12,17 +16,27 @@ export interface ObjectSchema {
   title?: string;
   properties: SchemaProperties;
 }
+
 export interface StringSchema {
   type: 'string';
   title: string;
   enum?: string[];
+  default?: string;
+}
+
+export interface IntegerSchema {
+  type: 'integer';
+  title: string;
+  minimum: number;
+  maximum: number;
+  multipleOf: number;
 }
 
 export function isStringSchema(schema: SchemaProperty): schema is StringSchema {
   return schema.type === 'string';
 }
 
-export type SchemaProperty = ObjectSchema | StringSchema;
+export type SchemaProperty = ObjectSchema | StringSchema | IntegerSchema;
 
 export interface UISchema {
   [key: string]: UISchemaItem;
@@ -31,7 +45,6 @@ export interface UISchema {
 // NOTE: keys for these interfaces follow the requirement for react-jsonSchema form
 // (https://mozilla-services.github.io/react-jsonschema-form/)
 export interface UISchemaItem {
-  'ui:autofocus'?: boolean;
   'ui:widget'?: string;
   'ui:placeholder'?: string;
   'ui:emptyValue'?: string;
@@ -42,9 +55,21 @@ export interface PropertyEditorSchema {
   schema: ObjectSchema;
 }
 
+// ------------------------------------------------------------------------------
+// Default UISchema objects for react-jsonschema-form
+// ------------------------------------------------------------------------------
 const DEFAULT_TEXT_UISCHEMA: UISchemaItem = {
-  'ui:autofocus': true,
   'ui:emptyValue': ''
+};
+
+const DEFAULT_DISCRETE_SCALE_ARRAY_UISCHEMA: UISchemaItem = {
+  ...DEFAULT_TEXT_UISCHEMA,
+  'ui:placeholder': 'a, b, c...'
+};
+
+const DEFAULT_CONTINUOUS_SCALE_ARRAY_UISCHEMA: UISchemaItem = {
+  ...DEFAULT_TEXT_UISCHEMA,
+  'ui:placeholder': 'Min, Max'
 };
 
 const DEFAULT_SELECT_UISCHEMA: UISchemaItem = {
@@ -53,6 +78,10 @@ const DEFAULT_SELECT_UISCHEMA: UISchemaItem = {
   'ui:emptyValue': 'auto'
 };
 
+// ------------------------------------------------------------------------------
+// Channel-Field Indexes for custom encoding
+// Key is Tab name, value is list of fieldDef properties
+// ------------------------------------------------------------------------------
 const POSITION_FIELD_QUANTITATIVE_INDEX = {
   'Common': [
     {
@@ -67,8 +96,7 @@ const POSITION_FIELD_QUANTITATIVE_INDEX = {
       prop: 'stack'
     }
   ],
-  'Scale': ['type'].map(p => ({prop: 'scale', nestedProp: p})),
-  'Axis': ['orient', 'title'].map(p => ({prop: 'axis', nestedProp: p}))
+  'Axis': ['orient', 'title'].map(p => ({prop: 'axis', nestedProp: p})),
 };
 
 const POSITION_FIELD_NOMINAL_INDEX = {
@@ -81,34 +109,65 @@ const POSITION_FIELD_TEMPORAL_INDEX = {
   'Axis': ['orient', 'title'].map(p => ({prop: 'axis', nestedProp: p}))
 };
 
-// Capitalize first letter for aesthetic purposes in form
-function toTitleCase(str: string) {
-  return str.replace(/\w\S*/g, txt => {
-    return txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase();
-  });
-}
+const COLOR_CHANNEL_FIELD_INDEX = {
+  'Legend': ['orient', 'title', 'type'].map(p => ({prop: 'legend', nestedProp: p})),
+  'Scale': ['domain', 'scheme', 'type'].map(p => ({prop: 'scale', nestedProp: p}))
+};
 
-function generateTitle(prop: string, nestedProp: string, propTab: string): string {
-  let title;
-  if (propTab === 'Common') {
-    title = nestedProp ? prop + ' ' + nestedProp : prop;
-  } else {
-    title = nestedProp || prop;
-  }
+const SIZE_CHANNEL_FIELD_INDEX = {
+  'Legend': ['orient', 'title', 'type'].map(p => ({prop: 'legend', nestedProp: p})),
+  'Scale': ['domain', 'range', 'type'].map(p => ({prop: 'scale', nestedProp: p}))
+};
 
-  return toTitleCase(title);
-}
+const SHAPE_CHANNEL_FIELD_INDEX = {
+  'Legend': ['orient', 'title'].map(p => ({prop: 'legend', nestedProp: p})),
+  'Scale': ['domain', 'range'].map(p => ({prop: 'scale', nestedProp: p}))
+};
 
-export function getPropertyEditorSchema(prop: string, nestedProp: string, propTab: string): PropertyEditorSchema {
+// ------------------------------------------------------------------------------
+// Color Scheme Constants
+// ------------------------------------------------------------------------------
+// TODO: Add all of the color schemes
+export const COLOR_SCHEMES = ['blues', 'greens', 'greys', 'purples', 'reds', 'oranges', 'viridis', 'inferno', 'magma',
+  'plasma', 'bluegreen', 'bluepurple', 'greenblue', 'orangered', 'blueorange', 'accent', 'category10', 'category20',
+  'category20b', 'category20c', 'dark2', 'paired', 'pastel1', 'pastel1', 'set1', 'set2', 'set3', 'tableau10',
+  'tableau20'];
+
+export const CATEGORICAL_COLOR_SCHEMES = ['accent', 'category10', 'category20', 'category20b', 'category20c', 'dark2',
+  'paired', 'pastel1', 'pastel1', 'set1', 'set2', 'set3', 'tableau10', 'tableau20'];
+
+export const SEQUENTIAL_COLOR_SCHEMES = ['blues', 'greens', 'greys', 'purples', 'reds', 'oranges', 'viridis', 'inferno',
+  'magma', 'plasma', 'bluegreen', 'bluepurple', 'greenblue', 'orangered', 'blueorange'];
+
+
+// ------------------------------------------------------------------------------
+// Generator/Factory Methods
+// ------------------------------------------------------------------------------
+export function generatePropertyEditorSchema(prop: string, nestedProp: string, propTab: string,
+                                             fieldDef: ShelfFieldDef): PropertyEditorSchema {
   const title = generateTitle(prop, nestedProp, propTab);
   if (prop === 'scale') {
     if (nestedProp === 'type') {
       const schemaProperty: StringSchema = {
         title: title,
-        enum: (vlSchema as any).definitions.ScaleType.enum,
+        enum: filterEnumElements(fieldDef, prop, nestedProp, (vlSchema as any).definitions.ScaleType.enum),
         type: 'string'
       };
       return generateSchema(prop, nestedProp, DEFAULT_SELECT_UISCHEMA, propTab, schemaProperty);
+    } else if (nestedProp === 'scheme') {
+      const schemaProperty: StringSchema = {
+        title: title,
+        enum: filterEnumElements(fieldDef, prop, nestedProp, COLOR_SCHEMES),
+        type: 'string'
+      };
+      return generateSchema(prop, nestedProp, DEFAULT_SELECT_UISCHEMA, propTab, schemaProperty);
+    } else if (nestedProp === 'range' || nestedProp === 'domain') {
+      const schemaProperty: StringSchema = {
+        title: title,
+        type: 'string'
+      };
+      return generateSchema(prop, nestedProp, isDiscrete(fieldDef) ?
+        DEFAULT_DISCRETE_SCALE_ARRAY_UISCHEMA : DEFAULT_CONTINUOUS_SCALE_ARRAY_UISCHEMA, propTab, schemaProperty);
     }
   } else if (prop === 'axis') {
     if (nestedProp === 'orient') {
@@ -132,11 +191,44 @@ export function getPropertyEditorSchema(prop: string, nestedProp: string, propTa
       type: 'string'
     };
     return generateSchema(prop, nestedProp, DEFAULT_SELECT_UISCHEMA, propTab, schemaProperty);
+  } else if (prop === 'size') {
+    const schemaProperty: StringSchema = {
+      title: title,
+      type: 'string'
+    };
+    return generateSchema(prop, nestedProp, DEFAULT_TEXT_UISCHEMA, propTab, schemaProperty);
+  } else if (prop === 'legend') {
+    if (nestedProp === 'orient') {
+      const schemaProperty: StringSchema = {
+        title: title,
+        type: 'string',
+        enum: (vlSchema as any).definitions.LegendOrient.enum
+      };
+      return generateSchema(prop, nestedProp, DEFAULT_SELECT_UISCHEMA, propTab, schemaProperty);
+    } else if (nestedProp === 'title') {
+      const schemaProperty: StringSchema = {
+        title: title,
+        type: 'string'
+      };
+      return generateSchema(prop, nestedProp, DEFAULT_TEXT_UISCHEMA, propTab, schemaProperty);
+    } else if (nestedProp === 'type') {
+      const schemaProperty: StringSchema = {
+        title: title,
+        type: 'string',
+        enum: (vlSchema as any).definitions.Legend.properties.type.enum,
+      };
+      return generateSchema(prop, nestedProp, DEFAULT_SELECT_UISCHEMA, propTab, schemaProperty);
+    }
+  } else if (prop === 'format') {
+    const schemaProperty: StringSchema = {
+      title: title,
+      type: 'string'
+    };
+    return generateSchema(prop, nestedProp, DEFAULT_TEXT_UISCHEMA, propTab, schemaProperty);
   } else {
     throw new Error('Property combination not recognized');
   }
 }
-
 
 /*
 *  NOTE: factory method where propertyKey follows naming convention: prop_nestedProp
@@ -159,7 +251,7 @@ function generateSchema(prop: string, nestedProp: string, uiSchemaItem: UISchema
 }
 
 export function getFieldPropertyGroupIndex(shelfId: ShelfId, fieldDef: ShelfFieldDef) {
-  if (shelfId.channel === Channel.X || shelfId.channel === Channel.Y) {
+  if (fieldDef && (shelfId.channel === Channel.X || shelfId.channel === Channel.Y)) {
     switch (fieldDef.type) {
       case ExpandedType.QUANTITATIVE:
         return POSITION_FIELD_QUANTITATIVE_INDEX;
@@ -170,6 +262,12 @@ export function getFieldPropertyGroupIndex(shelfId: ShelfId, fieldDef: ShelfFiel
       case ExpandedType.TEMPORAL:
         return POSITION_FIELD_TEMPORAL_INDEX;
     }
+  } else if (shelfId.channel === Channel.COLOR) {
+    return COLOR_CHANNEL_FIELD_INDEX;
+  } else if (shelfId.channel === Channel.SIZE) {
+    return SIZE_CHANNEL_FIELD_INDEX;
+  } else if (shelfId.channel === Channel.SHAPE) {
+    return SHAPE_CHANNEL_FIELD_INDEX;
   }
 }
 
@@ -181,9 +279,59 @@ export function generateFormData(shelfId: ShelfId, fieldDef: ShelfFieldDef) {
       const prop = customProp.prop;
       const nestedProp = customProp.nestedProp;
       const propertyKey = nestedProp ? prop + '_' + nestedProp : prop;
-      formData[propertyKey] = fieldDef[prop] ? nestedProp ? fieldDef[prop][nestedProp] : fieldDef[prop] : undefined;
+      const fData = fieldDef[prop] ? nestedProp ? fieldDef[prop][nestedProp] : fieldDef[prop] : undefined;
+      // handle empty input for text input
+      formData[propertyKey] = fData === '?' ? '' : fData;
     }
   }
 
   return formData;
+}
+
+function filterEnumElements(fieldDef: ShelfFieldDef, prop: string, nestedProp: string, possibleVals: string[]) {
+  if (prop === 'scale') {
+    if (nestedProp === 'type') {
+      if (isSequential(fieldDef)) {
+        return ["linear", "pow", "sqrt", "log", "time", "utc", "sequential"];
+      }
+      return ["ordinal", "point", "band"];
+    } else if (nestedProp === 'scheme') {
+      if (isSequential(fieldDef)) {
+        return SEQUENTIAL_COLOR_SCHEMES;
+      }
+      return CATEGORICAL_COLOR_SCHEMES;
+    }
+  }
+
+  return possibleVals;
+}
+
+// ------------------------------------------------------------------------------
+// General-Purpose Helper Methods
+// ------------------------------------------------------------------------------
+export function isSequential(fieldDef: ShelfFieldDef) {
+  return contains([ExpandedType.ORDINAL, ExpandedType.TEMPORAL, ExpandedType.QUANTITATIVE], fieldDef.type);
+}
+
+export function isDiscrete(fieldDef: ShelfFieldDef) {
+  return !isSequential(fieldDef);
+}
+
+// Capitalize first letter for aesthetic purposes in form
+function toTitleCase(str: string) {
+  return str.replace(/\w\S*/g, txt => {
+    return txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase();
+  });
+}
+
+// Generate title for react-form with appropriate casing, prop, nestedProp
+function generateTitle(prop: string, nestedProp: string, propTab: string): string {
+  let title;
+  if (propTab === 'Common') {
+    title = nestedProp ? prop + ' ' + nestedProp : prop;
+  } else {
+    title = nestedProp || prop;
+  }
+
+  return toTitleCase(title);
 }

--- a/src/components/encoding-pane/property-editor-schema.ts
+++ b/src/components/encoding-pane/property-editor-schema.ts
@@ -148,13 +148,13 @@ export function generatePropertyEditorSchema(prop: string, nestedProp: string, p
     if (nestedProp === 'type') {
       // Filtering based on channel type & fieldDef type
       const scaleTypes: string[] = getSupportedScaleTypes(shelfId, fieldDef);
-      const propertySchema: StringSchema = {
+      const propertySchema = {
         ...baseUISchema,
         enum: scaleTypes,
       };
       return generateSchema(prop, nestedProp, DEFAULT_SELECT_UISCHEMA, propTab, propertySchema);
     } else if (nestedProp === 'scheme') {
-      const propertySchema: StringSchema = {
+      const propertySchema = {
         ...baseUISchema,
         enum: isContinuous(fieldDef) ? SEQUENTIAL_COLOR_SCHEMES : CATEGORICAL_COLOR_SCHEMES,
       };
@@ -165,7 +165,7 @@ export function generatePropertyEditorSchema(prop: string, nestedProp: string, p
     }
   } else if (prop === 'axis') {
     if (nestedProp === 'orient') {
-      const propertySchema: StringSchema = {
+      const propertySchema = {
         ...baseUISchema,
         enum: channel === 'y' ? ['left', 'right'] : ['top', 'bottom']
       };
@@ -174,7 +174,7 @@ export function generatePropertyEditorSchema(prop: string, nestedProp: string, p
       return generateSchema(prop, nestedProp, DEFAULT_TEXT_UISCHEMA, propTab, baseUISchema);
     }
   } else if (prop === 'stack') {
-    const propertySchema: StringSchema = {
+    const propertySchema = {
       ...baseUISchema,
       enum: (vlSchema as any).definitions.StackOffset.enum,
     };
@@ -183,7 +183,7 @@ export function generatePropertyEditorSchema(prop: string, nestedProp: string, p
     return generateSchema(prop, nestedProp, DEFAULT_TEXT_UISCHEMA, propTab, baseUISchema);
   } else if (prop === 'legend') {
     if (nestedProp === 'orient') {
-      const propertySchema: StringSchema = {
+      const propertySchema = {
         ...baseUISchema,
         enum: (vlSchema as any).definitions.LegendOrient.enum
       };
@@ -191,7 +191,7 @@ export function generatePropertyEditorSchema(prop: string, nestedProp: string, p
     } else if (nestedProp === 'title') {
       return generateSchema(prop, nestedProp, DEFAULT_TEXT_UISCHEMA, propTab, baseUISchema);
     } else if (nestedProp === 'type') {
-      const propertySchema: StringSchema = {
+      const propertySchema = {
         ...baseUISchema,
         enum: (vlSchema as any).definitions.Legend.properties.type.enum,
       };

--- a/src/components/encoding-pane/property-editor-schema.ts
+++ b/src/components/encoding-pane/property-editor-schema.ts
@@ -82,25 +82,9 @@ const DEFAULT_SELECT_UISCHEMA: UISchemaItem = {
 // Channel-Field Indexes for custom encoding
 // Key is Tab name, value is list of fieldDef properties
 // ------------------------------------------------------------------------------
-const POSITION_FIELD_QUANTITATIVE_INDEX = {
-  'Common': [
-    {
-      prop: 'scale',
-      nestedProp: 'type'
-    },
-    {
-      prop: 'axis',
-      nestedProp: 'title'
-    },
-    {
-      prop: 'axis',
-      nestedProp: 'orient'
-    },
-    {
-      prop: 'stack'
-    }
-  ],
-};
+
+const AXIS_ORIENT_TITLE = ['title', 'orient'].map(p => ({prop: 'axis', nestedProp: p}));
+const LEGEND_ORIENT_TITLE = ['orient', 'title'].map(p => ({prop: 'legend', nestedProp: p}));
 
 const POSITION_FIELD_NOMINAL_INDEX = {
   'Common': [
@@ -108,71 +92,34 @@ const POSITION_FIELD_NOMINAL_INDEX = {
       prop: 'scale',
       nestedProp: 'type'
     },
-    {
-      prop: 'axis',
-      nestedProp: 'orient'
-    },
-    {
-      prop: 'axis',
-      nestedProp: 'title'
-    }
+    ...AXIS_ORIENT_TITLE
   ]
 };
 
-const POSITION_FIELD_TEMPORAL_INDEX = {
-  'Scale': ['type'].map(p => ({prop: 'scale', nestedProp: p})),
-  'Axis': ['orient', 'title'].map(p => ({prop: 'axis', nestedProp: p}))
+// TODO: this should differ in the future
+const POSITION_FIELD_TEMPORAL_INDEX = POSITION_FIELD_NOMINAL_INDEX;
+
+const POSITION_FIELD_QUANTITATIVE_INDEX = {
+  'Common': [
+    ...POSITION_FIELD_NOMINAL_INDEX['Common'],
+    {prop: 'stack'}
+  ]
 };
 
 const COLOR_CHANNEL_FIELD_INDEX = {
-  'Common': [
-    {
-      prop: 'legend',
-      nestedProp: 'title'
-    },
-    {
-      prop: 'scale',
-      nestedProp: 'scheme'
-    }
-  ],
   'Legend': ['orient', 'title', 'type'].map(p => ({prop: 'legend', nestedProp: p})),
-  'Scale': ['domain', 'scheme', 'type'].map(p => ({prop: 'scale', nestedProp: p}))
+  'Scale': ['type', 'domain', 'scheme'].map(p => ({prop: 'scale', nestedProp: p}))
 };
 
 const SIZE_CHANNEL_FIELD_INDEX = {
-  'Common': [
-    {
-      prop: 'legend',
-      nestedProp: 'title'
-    },
-    {
-      prop: 'scale',
-      nestedProp: 'type'
-    }
-  ],
   'Legend': ['orient', 'title'].map(p => ({prop: 'legend', nestedProp: p})),
-  'Scale': ['domain', 'range', 'type'].map(p => ({prop: 'scale', nestedProp: p}))
+  'Scale': ['type', 'domain', 'range'].map(p => ({prop: 'scale', nestedProp: p}))
 };
 
 const SHAPE_CHANNEL_FIELD_INDEX = {
-  'Common': [
-    {
-      prop: 'legend',
-      nestedProp: 'orient'
-    },
-    {
-      prop: 'legend',
-      nestedProp: 'title'
-    },
-    {
-      prop: 'scale',
-      nestedProp: 'domain'
-    },
-    {
-      prop: 'scale',
-      nestedProp: 'range'
-    }
-  ]
+  'Legend': LEGEND_ORIENT_TITLE,
+  // No need to adjust scale type for shape
+  'Scale': ['domain', 'range'].map(p => ({prop: 'scale', nestedProp: p}))
 };
 
 // ------------------------------------------------------------------------------

--- a/src/components/encoding-pane/property-editor-schema.ts
+++ b/src/components/encoding-pane/property-editor-schema.ts
@@ -190,7 +190,7 @@ export const SEQUENTIAL_COLOR_SCHEMES = ['blues', 'greens', 'greys', 'purples', 
 export function generatePropertyEditorSchema(prop: string, nestedProp: string, propTab: string,
                                              fieldDef: ShelfFieldDef, shelfId: ShelfId): PropertyEditorSchema {
   const title = generateTitle(prop, nestedProp, propTab);
-  const baseUiSchema: SchemaProperty = {
+  const baseUISchema: SchemaProperty = {
     title: title,
     type: 'string'
   };
@@ -199,72 +199,57 @@ export function generatePropertyEditorSchema(prop: string, nestedProp: string, p
     if (nestedProp === 'type') {
       // Filtering based on channel type & fieldDef type
       const scaleTypes: string[] = getSupportedScaleTypes(shelfId, fieldDef);
-      const schemaProperty: StringSchema = {
-        ...baseUiSchema,
+      const propertySchema: StringSchema = {
+        ...baseUISchema,
         enum: scaleTypes,
       };
-      return generateSchema(prop, nestedProp, DEFAULT_SELECT_UISCHEMA, propTab, schemaProperty);
+      return generateSchema(prop, nestedProp, DEFAULT_SELECT_UISCHEMA, propTab, propertySchema);
     } else if (nestedProp === 'scheme') {
-      const schemaProperty: StringSchema = {
-        ...baseUiSchema,
+      const propertySchema: StringSchema = {
+        ...baseUISchema,
         enum: isContinuous(fieldDef) ? SEQUENTIAL_COLOR_SCHEMES : CATEGORICAL_COLOR_SCHEMES,
       };
-      return generateSchema(prop, nestedProp, DEFAULT_SELECT_UISCHEMA, propTab, schemaProperty);
+      return generateSchema(prop, nestedProp, DEFAULT_SELECT_UISCHEMA, propTab, propertySchema);
     } else if (nestedProp === 'range' || nestedProp === 'domain') {
-      const schemaProperty: StringSchema = {
-        ...baseUiSchema
-      };
       return generateSchema(prop, nestedProp, isDiscrete(fieldDef) ?
-        DEFAULT_DISCRETE_SCALE_ARRAY_UISCHEMA : DEFAULT_CONTINUOUS_SCALE_ARRAY_UISCHEMA, propTab, schemaProperty);
+        DEFAULT_DISCRETE_SCALE_ARRAY_UISCHEMA : DEFAULT_CONTINUOUS_SCALE_ARRAY_UISCHEMA, propTab, baseUISchema);
     }
   } else if (prop === 'axis') {
     if (nestedProp === 'orient') {
-      const schemaProperty: StringSchema = {
-        ...baseUiSchema,
+      const propertySchema: StringSchema = {
+        ...baseUISchema,
         enum: (vlSchema as any).definitions.AxisOrient.enum,
       };
-      return generateSchema(prop, nestedProp, DEFAULT_SELECT_UISCHEMA, propTab, schemaProperty);
+      return generateSchema(prop, nestedProp, DEFAULT_SELECT_UISCHEMA, propTab, propertySchema);
     } else if (nestedProp === 'title') {
-      const schemaProperty: StringSchema = {
-        ...baseUiSchema
-      };
-      return generateSchema(prop, nestedProp, DEFAULT_TEXT_UISCHEMA, propTab, schemaProperty);
+      return generateSchema(prop, nestedProp, DEFAULT_TEXT_UISCHEMA, propTab, baseUISchema);
     }
   } else if (prop === 'stack') {
-    const schemaProperty: StringSchema = {
-      ...baseUiSchema,
+    const propertySchema: StringSchema = {
+      ...baseUISchema,
       enum: (vlSchema as any).definitions.StackOffset.enum,
     };
-    return generateSchema(prop, nestedProp, DEFAULT_SELECT_UISCHEMA, propTab, schemaProperty);
+    return generateSchema(prop, nestedProp, DEFAULT_SELECT_UISCHEMA, propTab, propertySchema);
   } else if (prop === 'size') {
-    const schemaProperty: StringSchema = {
-      ...baseUiSchema
-    };
-    return generateSchema(prop, nestedProp, DEFAULT_TEXT_UISCHEMA, propTab, schemaProperty);
+    return generateSchema(prop, nestedProp, DEFAULT_TEXT_UISCHEMA, propTab, baseUISchema);
   } else if (prop === 'legend') {
     if (nestedProp === 'orient') {
-      const schemaProperty: StringSchema = {
-        ...baseUiSchema,
+      const propertySchema: StringSchema = {
+        ...baseUISchema,
         enum: (vlSchema as any).definitions.LegendOrient.enum
       };
-      return generateSchema(prop, nestedProp, DEFAULT_SELECT_UISCHEMA, propTab, schemaProperty);
+      return generateSchema(prop, nestedProp, DEFAULT_SELECT_UISCHEMA, propTab, propertySchema);
     } else if (nestedProp === 'title') {
-      const schemaProperty: StringSchema = {
-        ...baseUiSchema
-      };
-      return generateSchema(prop, nestedProp, DEFAULT_TEXT_UISCHEMA, propTab, schemaProperty);
+      return generateSchema(prop, nestedProp, DEFAULT_TEXT_UISCHEMA, propTab, baseUISchema);
     } else if (nestedProp === 'type') {
-      const schemaProperty: StringSchema = {
-        ...baseUiSchema,
+      const propertySchema: StringSchema = {
+        ...baseUISchema,
         enum: (vlSchema as any).definitions.Legend.properties.type.enum,
       };
-      return generateSchema(prop, nestedProp, DEFAULT_SELECT_UISCHEMA, propTab, schemaProperty);
+      return generateSchema(prop, nestedProp, DEFAULT_SELECT_UISCHEMA, propTab, propertySchema);
     }
   } else if (prop === 'format') {
-    const schemaProperty: StringSchema = {
-      ...baseUiSchema
-    };
-    return generateSchema(prop, nestedProp, DEFAULT_TEXT_UISCHEMA, propTab, schemaProperty);
+    return generateSchema(prop, nestedProp, DEFAULT_TEXT_UISCHEMA, propTab, baseUISchema);
   } else {
     throw new Error('Property combination not recognized');
   }
@@ -273,34 +258,35 @@ export function generatePropertyEditorSchema(prop: string, nestedProp: string, p
 
 // TODO: Eventually refactor to Vega-Lite
 function getSupportedScaleTypes(shelfId: ShelfId, fieldDef: ShelfFieldDef): string[] {
-  let scaleTypes: string[] = [];
-  if (contains([Channel.X, Channel.Y], shelfId.channel)) {
-    if (fieldDef.type === ExpandedType.QUANTITATIVE) {
-      scaleTypes = ["linear", "log", "pow", "sqrt"];
-    } else if (fieldDef.type === ExpandedType.TEMPORAL) {
-      scaleTypes = ["bin-linear", "time", "utc", "ordinal", "bin-ordinal", "point", "band"];
-    } else if (fieldDef.type === ExpandedType.NOMINAL || fieldDef.type === ExpandedType.ORDINAL) {
-      scaleTypes = ["point", "band"];
-    }
-  } else if (shelfId.channel === Channel.COLOR) {
-    if (fieldDef.type === ExpandedType.QUANTITATIVE) {
-      scaleTypes = ["linear", "pow", "sqrt", "log", "sequential"];
-    } else if (fieldDef.type === ExpandedType.NOMINAL || fieldDef.type === ExpandedType.ORDINAL) {
-      scaleTypes = ["ordinal", "point"];
-    } else if (fieldDef.type === ExpandedType.TEMPORAL) {
-      scaleTypes = ["time", "utc", "sequential"];
-    }
-  } else if (shelfId.channel === Channel.SIZE) {
-    if (fieldDef.type === ExpandedType.QUANTITATIVE) {
-      scaleTypes = ["linear", "pow", "sqrt", "log"];
-    } else if (fieldDef.type === ExpandedType.NOMINAL || fieldDef.type === ExpandedType.ORDINAL) {
-      scaleTypes = ["point", "band"];
-    } else if (fieldDef.type === ExpandedType.TEMPORAL) {
-      scaleTypes = ["bin-linear", "time", "utc", "ordinal", "bin-ordinal", "point", "band"];
-    }
+  switch (fieldDef.type) {
+    case ExpandedType.QUANTITATIVE:
+      if (contains([Channel.X, Channel.Y], shelfId.channel)) {
+        return ["linear", "log", "pow", "sqrt"];
+      } else if (shelfId.channel === Channel.COLOR) {
+        return ["linear", "pow", "sqrt", "log", "sequential"];
+      } else if (shelfId.channel === Channel.SIZE) {
+        return ["linear", "pow", "sqrt", "log"];
+      }
+    case ExpandedType.ORDINAL:
+    case ExpandedType.NOMINAL:
+      if (contains([Channel.X, Channel.Y], shelfId.channel)) {
+        return ["point", "band"];
+      } else if (shelfId.channel === Channel.COLOR) {
+        return ["ordinal"];
+      } else if (shelfId.channel === Channel.SIZE) {
+        return ["point", "band"];
+      }
+    case ExpandedType.TEMPORAL:
+      if (contains([Channel.X, Channel.Y], shelfId.channel)) {
+        return ["time", "utc"];
+      } else if (shelfId.channel === Channel.COLOR) {
+        return ["time", "utc", "sequential"];
+      } else if (shelfId.channel === Channel.SIZE) {
+        return ["time", "utc"];
+      }
+    default:
+      return [];
   }
-
-  return scaleTypes;
 }
 
 /*

--- a/src/components/encoding-pane/property-editor-schema.ts
+++ b/src/components/encoding-pane/property-editor-schema.ts
@@ -341,7 +341,7 @@ export function generateFormData(shelfId: ShelfId, fieldDef: ShelfFieldDef) {
       const fData = fieldDef[prop] ? nestedProp ? fieldDef[prop][nestedProp] : fieldDef[prop] : undefined;
       // Display empty string when '?' is passed in to retrieve default value
       // '?' is passed when formData is empty to avoid passing in empty string as a property/nestedProp value
-      formData[propertyKey] = fData === '?' ? '' : fData;
+      formData[propertyKey] = fData === undefined ? '' : fData;
     }
   }
 

--- a/src/components/encoding-pane/property-editor-schema.ts
+++ b/src/components/encoding-pane/property-editor-schema.ts
@@ -142,6 +142,8 @@ export function generatePropertyEditorSchema(prop: string, nestedProp: string, p
     type: 'string'
   };
 
+  const {channel} = shelfId;
+
   if (prop === 'scale') {
     if (nestedProp === 'type') {
       // Filtering based on channel type & fieldDef type
@@ -165,7 +167,7 @@ export function generatePropertyEditorSchema(prop: string, nestedProp: string, p
     if (nestedProp === 'orient') {
       const propertySchema: StringSchema = {
         ...baseUISchema,
-        enum: (vlSchema as any).definitions.AxisOrient.enum,
+        enum: channel === 'y' ? ['left', 'right'] : ['top', 'bottom']
       };
       return generateSchema(prop, nestedProp, DEFAULT_SELECT_UISCHEMA, propTab, propertySchema);
     } else if (nestedProp === 'title') {

--- a/src/components/encoding-pane/property-editor.tsx
+++ b/src/components/encoding-pane/property-editor.tsx
@@ -27,7 +27,7 @@ export class PropertyEditorBase extends React.PureComponent<PropertyEditorProps,
 
   public render() {
     const {prop, nestedProp, propTab, shelfId, fieldDef} = this.props;
-    const {schema, uiSchema} = generatePropertyEditorSchema(prop, nestedProp, propTab, fieldDef);
+    const {schema, uiSchema} = generatePropertyEditorSchema(prop, nestedProp, propTab, fieldDef, shelfId);
     const formData = generateFormData(shelfId, fieldDef);
     return (
       <div styleName="property-editor">
@@ -87,6 +87,7 @@ export class PropertyEditorBase extends React.PureComponent<PropertyEditorProps,
           // TODO: Not supported yet
           throw new Error('Voyager does not currently support temporal domain values');
         }
+        // if form data is empty, default to auto suggested view, which is ? in compass
         return result === '' ? '?' : domain;
       }
     }

--- a/src/components/encoding-pane/property-editor.tsx
+++ b/src/components/encoding-pane/property-editor.tsx
@@ -72,13 +72,16 @@ export class PropertyEditorBase extends React.PureComponent<PropertyEditorProps,
   private parseFormDataResult(result: string) {
     const {fieldDef, prop, nestedProp} = this.props;
     const reg = /\s*,\s*/; // regex for parsing comma delimited strings
+    if (result === '') {
+      return undefined;
+    }
     if (prop === 'scale') {
       if (nestedProp === 'range') {
         const range = result.split(reg);
         if (isContinuous(fieldDef) && range.length !== 2) {
           throw new Error('Invalid format for range. Must follow format: Min Number, Max Number');
         }
-        return result === '' ? '?' : range;
+        return result === '' ? undefined : range;
       } else if (nestedProp === 'domain') {
         const domain = result.split(reg);
         if (fieldDef.type === ExpandedType.QUANTITATIVE && domain.length !== 2) {
@@ -87,12 +90,12 @@ export class PropertyEditorBase extends React.PureComponent<PropertyEditorProps,
           // TODO: Not supported yet
           throw new Error('Voyager does not currently support temporal domain values');
         }
-        return result === '' ? '?' : domain;
+        return result === '' ? undefined : domain;
       }
     }
 
     // if form data is empty, default to auto suggested view, which is ? in compass
-    return result === '' ? '?' : result;
+    return result === '' ? undefined : result;
   }
 
 }

--- a/src/components/encoding-pane/property-editor.tsx
+++ b/src/components/encoding-pane/property-editor.tsx
@@ -6,7 +6,7 @@ import {debounce} from 'throttle-debounce';
 import {ActionHandler} from '../../actions';
 import {SPEC_FIELD_NESTED_PROP_CHANGE, SPEC_FIELD_PROP_CHANGE, SpecEncodingAction} from '../../actions/shelf';
 import {ShelfFieldDef, ShelfId} from '../../models/shelf/spec';
-import {generateFormData, generatePropertyEditorSchema, isSequential} from './property-editor-schema';
+import {generateFormData, generatePropertyEditorSchema, isContinuous} from './property-editor-schema';
 import * as styles from './property-editor.scss';
 
 export interface PropertyEditorProps extends ActionHandler<SpecEncodingAction> {
@@ -75,14 +75,14 @@ export class PropertyEditorBase extends React.PureComponent<PropertyEditorProps,
     if (prop === 'scale') {
       if (nestedProp === 'range') {
         const range = result.split(reg);
-        if (isSequential(fieldDef) && range.length !== 2) {
-          throw new Error('Invalid format for range. Must be of type [min, max]');
+        if (isContinuous(fieldDef) && range.length !== 2) {
+          throw new Error('Invalid format for range. Must follow format: min, max');
         }
         return result === '' ? '?' : range;
       } else if (nestedProp === 'domain') {
         const domain = result.split(reg);
         if (fieldDef.type === ExpandedType.QUANTITATIVE && domain.length !== 2) {
-          throw new Error('Invalid format for domain. Must be of type [min, max]');
+          throw new Error('Invalid format for domain. Must follow format: min, max');
         } else if (fieldDef.type === ExpandedType.TEMPORAL) {
           // TODO: Not supported yet
           throw new Error('Voyager does not currently support temporal domain values');

--- a/src/components/encoding-pane/property-editor.tsx
+++ b/src/components/encoding-pane/property-editor.tsx
@@ -1,3 +1,4 @@
+import {ExpandedType} from 'compassql/build/src/query/expandedtype';
 import * as React from 'react';
 import * as CSSModules from 'react-css-modules';
 import Form from 'react-jsonschema-form';
@@ -5,7 +6,7 @@ import {debounce} from 'throttle-debounce';
 import {ActionHandler} from '../../actions';
 import {SPEC_FIELD_NESTED_PROP_CHANGE, SPEC_FIELD_PROP_CHANGE, SpecEncodingAction} from '../../actions/shelf';
 import {ShelfFieldDef, ShelfId} from '../../models/shelf/spec';
-import {generateFormData, getPropertyEditorSchema} from './property-editor-schema';
+import {generateFormData, generatePropertyEditorSchema, isSequential} from './property-editor-schema';
 import * as styles from './property-editor.scss';
 
 export interface PropertyEditorProps extends ActionHandler<SpecEncodingAction> {
@@ -26,7 +27,7 @@ export class PropertyEditorBase extends React.PureComponent<PropertyEditorProps,
 
   public render() {
     const {prop, nestedProp, propTab, shelfId, fieldDef} = this.props;
-    const {schema, uiSchema} = getPropertyEditorSchema(prop, nestedProp, propTab);
+    const {schema, uiSchema} = generatePropertyEditorSchema(prop, nestedProp, propTab, fieldDef);
     const formData = generateFormData(shelfId, fieldDef);
     return (
       <div styleName="property-editor">
@@ -45,7 +46,7 @@ export class PropertyEditorBase extends React.PureComponent<PropertyEditorProps,
 
   protected changeFieldProperty(result: any) {
     const {prop, nestedProp, shelfId, handleAction} = this.props;
-    const value = result.formData[Object.keys(result.formData)[0]];
+    const value = this.parseFormDataResult(result.formData[Object.keys(result.formData)[0]]);
     if (nestedProp) {
       handleAction({
         type: SPEC_FIELD_NESTED_PROP_CHANGE,
@@ -67,7 +68,32 @@ export class PropertyEditorBase extends React.PureComponent<PropertyEditorProps,
       });
     }
   }
+
+  private parseFormDataResult(result: string) {
+    const {fieldDef, prop, nestedProp} = this.props;
+    const reg = /\s*,\s*/; // regex for parsing comma delimited strings
+    if (prop === 'scale') {
+      if (nestedProp === 'range') {
+        const range = result.split(reg);
+        if (isSequential(fieldDef) && range.length !== 2) {
+          throw new Error('Invalid format for range. Must be of type [min, max]');
+        }
+        return result === '' ? '?' : range;
+      } else if (nestedProp === 'domain') {
+        const domain = result.split(reg);
+        if (fieldDef.type === ExpandedType.QUANTITATIVE && domain.length !== 2) {
+          throw new Error('Invalid format for domain. Must be of type [min, max]');
+        } else if (fieldDef.type === ExpandedType.TEMPORAL) {
+          // TODO: Not supported yet
+          throw new Error('Voyager does not currently support temporal domain values');
+        }
+        return result === '' ? '?' : domain;
+      }
+    }
+
+    return result === '' ? '?' : result;
+  }
+
 }
 
 export const PropertyEditor = CSSModules(PropertyEditorBase, styles);
-

--- a/src/components/encoding-pane/property-editor.tsx
+++ b/src/components/encoding-pane/property-editor.tsx
@@ -76,22 +76,22 @@ export class PropertyEditorBase extends React.PureComponent<PropertyEditorProps,
       if (nestedProp === 'range') {
         const range = result.split(reg);
         if (isContinuous(fieldDef) && range.length !== 2) {
-          throw new Error('Invalid format for range. Must follow format: min, max');
+          throw new Error('Invalid format for range. Must follow format: Min Number, Max Number');
         }
         return result === '' ? '?' : range;
       } else if (nestedProp === 'domain') {
         const domain = result.split(reg);
         if (fieldDef.type === ExpandedType.QUANTITATIVE && domain.length !== 2) {
-          throw new Error('Invalid format for domain. Must follow format: min, max');
+          throw new Error('Invalid format for domain. Must follow format: Min Number, Max Number');
         } else if (fieldDef.type === ExpandedType.TEMPORAL) {
           // TODO: Not supported yet
           throw new Error('Voyager does not currently support temporal domain values');
         }
-        // if form data is empty, default to auto suggested view, which is ? in compass
         return result === '' ? '?' : domain;
       }
     }
 
+    // if form data is empty, default to auto suggested view, which is ? in compass
     return result === '' ? '?' : result;
   }
 

--- a/src/models/shelf/spec/encoding.ts
+++ b/src/models/shelf/spec/encoding.ts
@@ -58,7 +58,6 @@ export interface ShelfFieldDef {
   description?: string;
 }
 
-
 export interface ShelfAnyEncodingDef extends ShelfFieldDef {
   channel: SHORT_WILDCARD;
 }


### PR DESCRIPTION
Extension of PR #789  and part of Issue #757

* Add support for Positional & Mark property channels (except text and detail, as `format` prop is not supported in Compass yet).
* Click outside of form will close field-customizer

Schema design & gifs for each mark encoding found here (for mark channels): https://docs.google.com/document/d/1n4pd6q3jMbZ_BYoSLYsMzTV9NOc25ZTJZ8oAGav3zP4/edit?usp=sharing




