### PR TITLE
Filter customizers only for channels that support customization

### DIFF
--- a/src/components/encoding-pane/encoding-shelf.tsx
+++ b/src/components/encoding-pane/encoding-shelf.tsx
@@ -19,7 +19,7 @@ import {DraggedFieldIdentifier, Field} from '../field/index';
 import * as styles from './encoding-shelf.scss';
 import {FieldCustomizer} from './field-customizer';
 import {FunctionPicker, FunctionPickerWildcardHandler} from './function-picker';
-import { CUSTOMIZABLE_ENCODING_CHANNELS } from './property-editor-schema';
+import {CUSTOMIZABLE_ENCODING_CHANNELS} from './property-editor-schema';
 
 /**
  * Props for react-dnd of EncodingShelf

--- a/src/components/encoding-pane/encoding-shelf.tsx
+++ b/src/components/encoding-pane/encoding-shelf.tsx
@@ -4,6 +4,7 @@ import * as React from 'react';
 import * as CSSModules from 'react-css-modules';
 import {ConnectDropTarget, DropTarget, DropTargetCollector, DropTargetSpec} from 'react-dnd';
 import * as TetherComponent from 'react-tether';
+import {contains} from 'vega-lite/build/src/util';
 import {ActionHandler} from '../../actions/index';
 import {
   SPEC_FIELD_ADD, SPEC_FIELD_MOVE, SPEC_FIELD_REMOVE, SPEC_FUNCTION_ADD_WILDCARD,
@@ -18,6 +19,7 @@ import {DraggedFieldIdentifier, Field} from '../field/index';
 import * as styles from './encoding-shelf.scss';
 import {FieldCustomizer} from './field-customizer';
 import {FunctionPicker, FunctionPickerWildcardHandler} from './function-picker';
+import { CUSTOMIZABLE_ENCODING_CHANNELS } from './property-editor-schema';
 
 /**
  * Props for react-dnd of EncodingShelf
@@ -86,7 +88,7 @@ class EncodingShelfBase extends React.PureComponent<
             attachment="top left"
             targetAttachment="bottom left"
           >
-            {(fieldDef && !isWildcardChannelId(id)) ?
+            {(fieldDef && !isWildcardChannelId(id) && contains(CUSTOMIZABLE_ENCODING_CHANNELS, id.channel)) ?
               <span onClick={this.toggleCustomizer} ref={this.fieldHandler}>
                 {channelName}{' '} <i className={'fa fa-caret-down'}/>
               </span> :

--- a/src/components/encoding-pane/property-editor-schema.ts
+++ b/src/components/encoding-pane/property-editor-schema.ts
@@ -58,6 +58,9 @@ export interface PropertyEditorSchema {
   schema: ObjectSchema;
 }
 
+// Currently supported customizble encoding channels that display caret in customizer UI
+export const CUSTOMIZABLE_ENCODING_CHANNELS = [Channel.X, Channel.Y, Channel.COLOR, Channel.SIZE, Channel.SHAPE];
+
 // ------------------------------------------------------------------------------
 // Channel-Field Indexes for custom encoding
 // Key is Tab name, value is list of fieldDef properties


### PR DESCRIPTION
Fix #804 

Disable customizer popup caret option for Detail channel. 
Created constant for channels that support encoding customization.


Brief demo showing customizer doesn't display caret for channels that have no customization supported yet. 

![detailchannel](https://user-images.githubusercontent.com/9298611/40039627-ef239644-57cb-11e8-818a-33eaac77f5ad.gif)
 