### PR TITLE
Remove vscode rule to add space between curly braces

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -17,5 +17,6 @@
   "files.trimTrailingWhitespace": true,
   "tslint.autoFixOnSave": true,
   "tsimporter.spaceBetweenBraces": false,
-  "tsimporter.filesToExclude": ["build/**", "lib-test/**"]
+  "tsimporter.filesToExclude": ["build/**", "lib-test/**"],
+  "typescript.format.insertSpaceAfterOpeningAndBeforeClosingNonemptyBraces": false
 }


### PR DESCRIPTION
Adds rule to disable adding spaces between curly braces for imports within VSCode.

