### PR TITLE
Add filter to only show stack property when domain is continuous

### DIFF
--- a/src/components/encoding-pane/property-editor-schema.ts
+++ b/src/components/encoding-pane/property-editor-schema.ts
@@ -280,6 +280,11 @@ export function getFieldPropertyGroupIndex(shelfId: ShelfId, fieldDef: ShelfFiel
   if (fieldDef && (shelfId.channel === Channel.X || shelfId.channel === Channel.Y)) {
     switch (fieldDef.type) {
       case ExpandedType.QUANTITATIVE:
+        if (!isContinuous(fieldDef)) {
+          return POSITION_FIELD_QUANTITATIVE_INDEX.Common.filter(t => {
+            return t.prop !== "stack";
+          });
+        }
         return POSITION_FIELD_QUANTITATIVE_INDEX;
 
       case ExpandedType.ORDINAL:


### PR DESCRIPTION
Fix #803 

According to VL documentation, `stack is only applicable for x and y channels with continuous domains`. 

This PR adds a filter to only show `stack` property when domain is continuous.
