### PR TITLE
Add maxWorkers flag to speed up Jest tests for CI

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,10 +31,10 @@
     "lint-fix": "npm run lint -- --fix",
     "tsc": "tsc",
     "test": "npm run tsc && npm run test:logic && npm run test:ui",
-    "test:logic": "TZ=America/Los_Angeles jest --no-cache --coverage",
+    "test:logic": "TZ=America/Los_Angeles jest --maxWorkers=4 --no-cache --coverage",
     "test:ui": "NODE_ENV=test node scripts/jest-ui.js",
     "posttest": "npm run lint",
-    "codecov": "jest --no-cache --coverage && codecov",
+    "codecov": "jest --no-cache --coverage --maxWorkers=4 && codecov",
     "deploy": "npm run clean && npm run lint && npm run test && scripts/publish.sh && node scripts/deploy.js"
   },
   "dependencies": {


### PR DESCRIPTION
Travis CI takes much longer than it should to run Jest tests, and the goal of this PR is to speed up CI, as current Travis builds for Voyager take over 15 minutes. 

According to Jest: "This defaults to the number of the cores available on your machine. It may be useful to adjust this in resource limited environments like CIs"

With the `maxWorkers` flag, CI build time is around 7-8 minutes.