### PR TITLE
Require node-sass 4.12.0 to support node 10 & 12

### DIFF
--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
     "gh-pages": "^1.0.0",
     "html-webpack-plugin": "^2.28.0",
     "jest": "20",
-    "node-sass": "^4.5.3",
+    "node-sass": "^4.12.0",
     "postcss-loader": "^1.3.3",
     "react-addons-test-utils": "15.4.2",
     "react-dev-utils": "^0.5.2",


### PR DESCRIPTION
### Problem

I tried to build from the `master` branch today and saw an error that says 

```
Node Sass does not yet support your current environment: OS X 64-bit with Unsupported runtime
``` 

<img width="1052" alt="Screen Shot 2019-06-19 at 2 21 21 PM" src="https://user-images.githubusercontent.com/822034/59804003-09e6f900-92a2-11e9-825d-c65392948d06.png">

I've tried building using `node v12.4.0` and `node v10.16.0` and the same error persists.

The error message mentioned node-sass version so I went and checked which node-sass version I was using. When I do a fresh clean clone of voyager and run `yarn install`, in the `/node_modules` folder I get `node-sass v4.5.3`. This is the minimal version required by voyager's `package.json`, but it only supports till node v8 https://github.com/sass/node-sass/releases/tag/v4.5.3


### Solution

Requiring the latest version of `node-sass` (`v4.12.0` as of today) solves my problem. (I find this solution a bit surprising though because I thought `yarn install` would install the latest `v4.x.x` version for me, but that wasn't the case)



### Sanity checks:
- [x] Make your pull request atomic, fixing one issue at a time unless there are many relevant issues that cannot be decoupled.
- [x] Make lint and test pass. (Run `npm run lint` and `npm run test`.)
- [x] Make sure you have rebased to the latest `master`.
- [x] Provide a concise title so that we can just copy it to our release note.
  - Use imperative mood and present tense.
  - Mention relevant issues. (e.g., `#1`)

