### PR TITLE
New Dockerfile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,10 @@ node_js:
 before_script:
  - export TZ=America/Los_Angeles
 script:
-  - npm run build -- --max-old-space-size=4096
+  - npm run build
   - npm run codecov
-  - npm run test:ui -- --max-old-space-size=4096
-  - npm run lint -- --max-old-space-size=4096
+  - npm run test:ui -- --max-old-space-size=8192
+  - npm run lint
 after_success:
   - bash <(curl -s https://codecov.io/bash)
 cache: yarn

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,10 @@ node_js:
 before_script:
  - export TZ=America/Los_Angeles
 script:
-  - npm run build
-  - npm run codecov
-  - npm run test:ui
-  - npm run lint
+  - npm run build -- --max-old-space-size=4096
+  - npm run codecov -- --max-old-space-size=4096
+  - npm run test:ui -- --max-old-space-size=4096
+  - npm run lint -- --max-old-space-size=4096
 after_success:
   - bash <(curl -s https://codecov.io/bash)
 cache: yarn

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,14 @@
 language: node_js
 node_js:
   - "6"
+env:
+  - NODE_OPTIONS=--max-old-space-size=8192
 before_script:
  - export TZ=America/Los_Angeles
 script:
   - npm run build
   - npm run codecov
-  - npm run test:ui -- --max-old-space-size=8192
+  - npm run test:ui
   - npm run lint
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ before_script:
  - export TZ=America/Los_Angeles
 script:
   - npm run build -- --max-old-space-size=4096
-  - npm run codecov -- --max-old-space-size=4096
+  - npm run codecov
   - npm run test:ui -- --max-old-space-size=4096
   - npm run lint -- --max-old-space-size=4096
 after_success:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM node:9.11.2
+
+COPY . /voyager
+
+RUN cd voyager && yarn && yarn build
+
+WORKDIR /voyager
+
+EXPOSE 9000
+
+CMD ["yarn", "start"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:9.11.2
+FROM node:6.17.1
 
 COPY . /voyager
 
@@ -8,4 +8,4 @@ WORKDIR /voyager
 
 EXPOSE 9000
 
-CMD ["yarn", "start"]
+CMD ["yarn", "start:headless"]

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ Build Docker image
 docker build -t vega/voyager .
 ```
 
-Run Docker container
+Run Docker container. The `-p 9000:9000` parameter is required to publish the container's yarn port to a host port, allowing users to view the datavoyager tool at http://localhost:9000/.
 ```
 docker run -p 9000:9000 vega/voyager
 ```

--- a/README.md
+++ b/README.md
@@ -156,3 +156,16 @@ This will run Voyager in "server-mode" sending requests to voyager-server, which
 The server url is controlled by the `SERVER` environment variable.
 
 See [voyager-server](https://github.com/vega/voyager-server) for more information on what portions of the functionality the server handles.
+
+## Docker
+Docker image based on [node:9.11.2](https://hub.docker.com/layers/node/library/node/9.11.2/images/sha256-571a95847b472f5a08c2287c3f36cfa4bb88c483fa5866504dc7cc8e3abfb588?context=explore)
+
+Build Docker image
+```
+docker build -t vega/voyager .
+```
+
+Run Docker container
+```
+docker run -p 9000:9000 vega/voyager
+```

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ The server url is controlled by the `SERVER` environment variable.
 See [voyager-server](https://github.com/vega/voyager-server) for more information on what portions of the functionality the server handles.
 
 ## Docker
-Docker image based on [node:9.11.2](https://hub.docker.com/layers/node/library/node/9.11.2/images/sha256-571a95847b472f5a08c2287c3f36cfa4bb88c483fa5866504dc7cc8e3abfb588?context=explore)
+Docker image based on [node:6.17.1](https://hub.docker.com/layers/node/library/node/6.17.1/images/sha256-0bb1f1235ffb537f2543de5fa0de7e4e93f522dd9cc6da51da255cffbdd99aa3?context=explore)
 
 Build Docker image
 ```
@@ -170,7 +170,7 @@ Run Docker container. The `-p 9000:9000` parameter is required to publish the co
 docker run -p 9000:9000 vega/voyager
 ```
 
-Alternatively run the Docker container detatched to not receive log information at standard out.
+Alternatively, run the Docker container detatched with `-d` to not receive log information in the console.
 ```
 docker run -d -p 9000:900 vega/voyager
 ```

--- a/README.md
+++ b/README.md
@@ -169,3 +169,8 @@ Run Docker container. The `-p 9000:9000` parameter is required to publish the co
 ```
 docker run -p 9000:9000 vega/voyager
 ```
+
+Alternatively run the Docker container detatched to not receive log information at standard out.
+```
+docker run -d -p 9000:900 vega/voyager
+```

--- a/config/webpack.config.dev.js
+++ b/config/webpack.config.dev.js
@@ -57,6 +57,7 @@ module.exports = {
     contentBase: path.resolve(__dirname, '../'),
     compress: true,
     hot: true,
+    host: '0.0.0.0',
     port: 9000
   },
 

--- a/config/webpack.config.lib.js
+++ b/config/webpack.config.lib.js
@@ -35,6 +35,7 @@ module.exports = {
   devServer: {
     contentBase: path.resolve(__dirname, '../'),
     compress: true,
+    host: '0.0.0.0',
     port: 9000
   },
 

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "// for postinstall need to rebuild sass. Otherwise, yarn would forgot to include vendor for node-sass": "",
     "postinstall": "npm rebuild node-sass",
     "start": "webpack-dev-server --open --config config/webpack.config.dev.js",
+    "start:headless": "webpack-dev-server --config config/webpack.config.dev.js",
     "start:server": "cross-env SERVER=\"http://localhost:3000\" webpack-dev-server --open --config config/webpack.config.dev.js",
     "build": "node scripts/build.js",
     "postbuild": "npm run tsc && npm run build:lib",


### PR DESCRIPTION
* Add Dockerfile to run datavoyager (would be nice to get this built and deployed to https://hub.docker.com/)
* Configured server to listen on 0.0.0.0 to open server up for Docker -- this has an artifact of opening other deployements up to all IPs, too
* Added yarn start:headless option to remove the `--open` parameter as it isn't needed in Docker
* Updated README.md with Docker build & run instructions

While running Travis CI build on my fork to verify my changes didn't break anything tested, I found the build has an out of memory error. I increased the `--max-old-space-size` to work around the issue.