### PR TITLE
Adds inline data to export from copy-button

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,1 @@
+theme: jekyll-theme-minimal


### PR DESCRIPTION
The current version would limit the data for the clipboard export to `"data":` { "name": "source"}`, but it's more helpful to export the self-contained chart with the inline data for quicker prototyping. One can always delete it, but adding it back is not as trivial. 

More specifically, I replaced the `this.specWithFilter` object in the main JS file by `Object.assign(this.specWithFilter, {data: {name: "source", values: this.props.data.values}}`, which does the trick.